### PR TITLE
improvements to JSDoc / JSDoc Toolkit support

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:     JavaScript
 " Maintainer:   Yi Zhao (ZHAOYI) <zzlinux AT hotmail DOT com>
-" Last Change By: Darrick Wiebe
-" Last Change:  August 25, 2010
-" Version:      0.7.8
-" Changes:      Disambiguate regex strings and mathematical statements
+" Last Change By: Marc Harter
+" Last Change:  February 18, 2011
+" Version:      0.7.9
+" Changes:      Updates JSDoc syntax
 "
 " TODO:
 "  - Add the HTML syntax inside the JSDoc
@@ -36,7 +36,7 @@ syntax region  javaScriptLineComment    start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$
 syntax region  javaScriptCvsTag         start="\$\cid:" end="\$" oneline contained
 syntax region  javaScriptComment        start="/\*"  end="\*/" contains=javaScriptCommentTodo,javaScriptCvsTag,@Spell fold
 
-"" JSDoc support start
+"" JSDoc / JSDoc Toolkit
 if !exists("javascript_ignore_javaScriptdoc")
   syntax case ignore
 
@@ -44,11 +44,23 @@ if !exists("javascript_ignore_javaScriptdoc")
   "syntax include @javaHtml <sfile>:p:h/html.vim
   "unlet b:current_syntax
 
-  syntax region javaScriptDocComment    matchgroup=javaScriptComment start="/\*\*\s*$"  end="\*/" contains=javaScriptDocTags,javaScriptCommentTodo,javaScriptCvsTag,@javaScriptHtml,@Spell fold
-  syntax match  javaScriptDocTags       contained "@\(param\|argument\|requires\|exception\|throws\|type\|class\|extends\|see\|link\|member\|module\|method\|title\|namespace\|optional\|default\|base\|file\)\>" nextgroup=javaScriptDocParam,javaScriptDocSeeTag skipwhite
-  syntax match  javaScriptDocTags       contained "@\(beta\|deprecated\|description\|fileoverview\|author\|license\|version\|returns\=\|constructor\|private\|protected\|final\|ignore\|addon\|exec\)\>"
-  syntax match  javaScriptDocParam      contained "\%(#\|\w\|\.\|:\|\/\)\+"
-  syntax region javaScriptDocSeeTag     contained matchgroup=javaScriptDocSeeTag start="{" end="}" contains=javaScriptDocTags
+  syntax region javaScriptDocComment      matchgroup=javaScriptComment start="/\*\*\s*"  end="\*/" contains=javaScriptDocTags,javaScriptCommentTodo,javaScriptCvsTag,@javaScriptHtml,@Spell fold
+
+  " tags containing a param
+  syntax match  javaScriptDocTags         contained "@\(augments\|base\|borrows\|class\|constructs\|default\|exception\|exports\|extends\|file\|member\|memberOf\|module\|name\|namespace\|optional\|requires\|title\|throws\|version\)\>" nextgroup=javaScriptDocParam skipwhite
+  " tags containing type and param
+  syntax match  javaScriptDocTags         contained "@\(argument\|param\|property\)\>" nextgroup=javaScriptDocType skipwhite
+  " tags containing type but no param
+  syntax match  javaScriptDocTags         contained "@\(type\|return\|returns\)\>" nextgroup=javaScriptDocTypeNoParam skipwhite
+  " tags containing references
+  syntax match  javaScriptDocTags         contained "@\(lends\|link\|see\)\>" nextgroup=javaScriptDocSeeTag skipwhite
+  " other tags (no extra syntax)
+  syntax match  javaScriptDocTags         contained "@\(access\|addon\|alias\|author\|beta\|constant\|constructor\|copyright\|deprecated\|description\|event\|example\|exec\|field\|fileOverview\|fileoverview\|function\|global\|ignore\|inner\|license\|overview\|private\|protected\|project\|public\|readonly\|since\|static\)\>"
+
+  syntax match  javaScriptDocType         contained "\%(#\|\"\|{\|}\|\w\|\.\|:\|\/\)\+" nextgroup=javaScriptDocParam skipwhite
+  syntax match  javaScriptDocTypeNoParam  contained "\%(#\|\"\|{\|}\|\w\|\.\|:\|\/\)\+"
+  syntax match  javaScriptDocParam        contained "\%(#\|\"\|{\|}\|\w\|\.\|:\|\/\)\+"
+  syntax region javaScriptDocSeeTag       contained matchgroup=javaScriptDocSeeTag start="{" end="}" contains=javaScriptDocTags
 
   syntax case match
 endif   "" JSDoc end
@@ -191,7 +203,9 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink javaScriptCvsTag               Function
   HiLink javaScriptDocTags              Special
   HiLink javaScriptDocSeeTag            Function
-  HiLink javaScriptDocParam             Function
+  HiLink javaScriptDocType              Type
+  HiLink javaScriptDocTypeNoParam       Type
+  HiLink javaScriptDocParam             Label
   HiLink javaScriptStringS              String
   HiLink javaScriptStringD              String
   HiLink javaScriptRegexpString         String


### PR DESCRIPTION
I added support for the most recent JSDoc (JSDoc Toolkit) tags.  Support for single line comments with syntax highlighting, e.g. /*\* @public */ .  And added a new class for type information where applicable (namely when dealing with parameters and return values).  Hope it helps!
