### PR TITLE
removed const as a 'future word'

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -97,7 +97,7 @@ syntax keyword javaScriptGlobalObjects  Array Boolean Date Function Infinity Jav
 
 syntax keyword javaScriptExceptions     Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 
-syntax keyword javaScriptFutureKeys     abstract enum int short boolean export interface static byte extends long super char final native synchronized class float package throws const goto private transient debugger implements protected volatile double import public
+syntax keyword javaScriptFutureKeys     abstract enum int short boolean export interface static byte extends long super char final native synchronized class float package throws goto private transient debugger implements protected volatile double import public
 
 "" DOM/HTML/CSS specified things
 


### PR DESCRIPTION
const is in use in v8 and SM (maybe Webkit), and is being used more and more in nodejs development, isn't really a future word.  plus future word highlighting overrides type highlighting for const making it not appear the same as var.
