### PR TITLE
Don't keep adding an extra indent for each continuation line

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -167,7 +167,7 @@ function s:IndentWithContinuation(lnum, ind, width)
   " TODO: the || s:IsInString() thing worries me a bit.
   if p_lnum != lnum
     if s:Match(p_lnum,s:continuation_regex)||s:IsInString(p_lnum,strlen(line))
-      return a:ind + a:width
+      return a:ind
     endif
   endif
 


### PR DESCRIPTION
Currently, indentation occurs as follows:

```
var s = "This" +
    "is" +
        "some" +
            "text"
```

Each line gets an extra indent added.

The following makes more sense:

```
var s = "This" +
    "is" +
    "some" +
    "text"
```

This pull request fixes this. Please have a look at it.

Thanks
