### PR TITLE
Match regexes that contain slashes in character classes

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -72,7 +72,8 @@ syntax case match
 syntax match   javaScriptSpecial        "\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\."
 syntax region  javaScriptStringD        start=+"+  skip=+\\\\\|\\$"+  end=+"+  contains=javaScriptSpecial,@htmlPreproc
 syntax region  javaScriptStringS        start=+'+  skip=+\\\\\|\\$'+  end=+'+  contains=javaScriptSpecial,@htmlPreproc
-syntax region  javaScriptRegexpString   start=+\(\([)\]"']\|\d\|\w\)\s*\)\@<!/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gim]\{,3}+ contains=javaScriptSpecial,@htmlPreproc oneline
+syntax region  javaScriptRegexpCharClass start=+\[\]\|\[^\]\|\[+ end=+\]+ contained
+syntax region  javaScriptRegexpString   start=+\(\([)\]"']\|\d\|\w\)\s*\)\@<!/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gim]\{,3}+ contains=javaScriptSpecial,javaScriptRegexpCharClass,@htmlPreproc oneline
 syntax match   javaScriptNumber         /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax match   javaScriptFloat          /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
 syntax match   javaScriptLabel          /\(?\s*\)\@<!\<\w\+\(\s*:\)\@=/
@@ -212,6 +213,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink javaScriptStringS              String
   HiLink javaScriptStringD              String
   HiLink javaScriptRegexpString         String
+  HiLink javaScriptRegexpCharClass      Character
   HiLink javaScriptCharacter            Character
   HiLink javaScriptPrototype            Type
   HiLink javaScriptConditional          Conditional


### PR DESCRIPTION
This matches regexes like `http/:\/\/[^/]*google[^/]+/`. Previously the syntax matcher would mistake the slash in `[^/]` for the end of the regex.

I've also taken care to match `[]x]` and `[^]x]` as valid character classes.
