### PR TITLE
Curly-braces around the type in @param allows spaces/non-word characters

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -60,7 +60,8 @@ if !exists("javascript_ignore_javaScriptdoc")
 
   syntax region javaScriptDocType         start="{" end="}" oneline contained nextgroup=javaScriptDocParam skipwhite
   syntax match  javaScriptDocType         contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+" nextgroup=javaScriptDocParam skipwhite
-  syntax match  javaScriptDocTypeNoParam  contained "\%(#\|\"\|{\|}\|\w\|\.\|:\|\/\)\+"
+  syntax region javaScriptDocTypeNoParam  start="{" end="}" oneline contained
+  syntax match  javaScriptDocTypeNoParam  contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+"
   syntax match  javaScriptDocParam        contained "\%(#\|\"\|{\|}\|\w\|\.\|:\|\/\)\+"
   syntax region javaScriptDocSeeTag       contained matchgroup=javaScriptDocSeeTag start="{" end="}" contains=javaScriptDocTags
 


### PR DESCRIPTION
I'm not a vim syntax master, but I made the "type" part of the @param accept anything inside curly braces for the type. I left the old style that allowed not-using curly-braces too, though maybe it should go away if everybody uses curly-braces.

ex:

/**
- @param {function(string, string)} callback The callback function...
  */
