### PR TITLE
Less specific syntax groups regexps

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -33,13 +33,13 @@ set cpo&vim
 " ============
 
 " Regex of syntax group names that are or delimit string or are comments.
-let s:syng_strcom = 'javaScript\%(String\|RegexpString\|CommentTodo\|LineComment\|Comment\|DocComment\)'
+let s:syng_strcom = 'string\|regex\|comment\c'
 
 " Regex of syntax group names that are strings.
-let s:syng_string = 'javaScript\%(RegexpString\)'
+let s:syng_string = 'regex\c'
 
 " Regex of syntax group names that are strings or documentation.
-let s:syng_stringdoc = 'javaScriptDocComment\|javaScriptComment'
+let s:syng_stringdoc = 'comment\c'
 
 " Expression used to check whether we should skip a match with searchpair().
 let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~ '".s:syng_strcom."'"


### PR DESCRIPTION
Instead of targetting the regular expressions to very specific syntax groups (ie: javaScriptDocComment), which make the indent script not compatible with other syntaxes (ie: jsComment), more generic versions are used which should still match the same groups by using case insensitive search and shorter patterns (string, regex and comment).

This modification works for the bundled syntax with Vim 7, the syntax version provided with the indent script as well as with this new javascript syntax: https://github.com/drslump/vim-syntax-js
