### PR TITLE
Detect .jsm files as JavaScript

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,2 +1,3 @@
 au BufNewFile,BufRead *.js setf javascript
+au BufNewFile,BufRead *.jsm setf javascript
 au BufNewFile,BufRead Jakefile setf javascript


### PR DESCRIPTION
Some people (like Mozilla projects) use the .jsm file extension to denote JavaScript "modules." I propose adding this detection out of the box.
