### PR TITLE
Missing JavaScript Global Objects

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -97,7 +97,7 @@ syntax keyword javaScriptRepeat         do while for
 syntax keyword javaScriptBranch         break continue switch case default return
 syntax keyword javaScriptStatement      try catch throw with finally
 
-syntax keyword javaScriptGlobalObjects  Array Boolean Date Function Infinity JavaArray JavaClass JavaObject JavaPackage Math Number NaN Object Packages RegExp String Undefined java netscape sun
+syntax keyword javaScriptGlobalObjects  Array Boolean Date Function Infinity JavaArray JavaClass JavaObject JavaPackage Math Number NaN Object Packages RegExp String Undefined console document history localStorage location java navigator netscape parent self sessionStorage sun top window
 
 syntax keyword javaScriptExceptions     Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 


### PR DESCRIPTION
Hi,

I noticed some important javascript global objects were not being highlighted. They are common across all browsers:

console document history localStorage location navigator parent self sessionStorage top window

I added them to the group javaScriptGlobalObjects.

Thanks.
