### PR TITLE
Missing Global Objects

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -106,7 +106,7 @@ syntax keyword javaScriptFutureKeys     abstract enum int short boolean export i
 "" DOM/HTML/CSS specified things
 
   " DOM2 Objects
-  syntax keyword javaScriptGlobalObjects  DOMImplementation DocumentFragment Document Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction
+  syntax keyword javaScriptGlobalObjects  DOMImplementation DocumentFragment Document Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction console document history localStorage location navigator parent self sessionStorage top window
   syntax keyword javaScriptExceptions     DOMException
 
   " DOM2 CONSTANT


### PR DESCRIPTION
Hi,

I noticed some important global objects were not being highlighted. They are common across all browsers:

console document history localStorage location navigator parent self sessionStorage top window

I added them to the group javaScriptGlobalObjects under the DOM section.

Thanks.
