### PR TITLE
multi-line var asignment indentation

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -59,7 +59,7 @@ let s:one_line_scope_regex = '\<\%(if\|else\|for\|while\)\>[^{;]*' . s:line_term
 let s:block_regex = '\%({\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term
 
 " Var string
-let s:var_regex = '\s*var\s.\+[^;]\s*\(//.*\)\?$'
+let s:var_regex = '\s*var\s[^;]\+$'
 
 " 2. Auxiliary Functions {{{1
 " ======================


### PR DESCRIPTION
I made this changes some time ago for standard indenter and now merged them with this project.

It has some limitations:
    - you need to use semicolons (it's quite common requirement)
    - you need not to use multi-line variables (like objects, arrays or functions) in this variables' declaration (it's not common, but more readable)

Maybe, it contains some bugs, but I didn't meet them yet.
