### PR TITLE
fix syntax for object label which contains '$'

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -78,7 +78,7 @@ syntax region  javaScriptRegexpCharClass start=+\[+ end=+\]+ contained
 syntax region  javaScriptRegexpString   start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gimy]\{,4}+ contains=javaScriptSpecial,javaScriptRegexpCharClass,@htmlPreproc oneline
 syntax match   javaScriptNumber         /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax match   javaScriptFloat          /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
-syntax match   javaScriptLabel          /\<\w\+\(\s*:\)\@=/
+syntax match   javaScriptLabel          /\<[[:alnum:]_$]\+\(\s*:\)\@=/
 
 "" JavaScript Prototype
 syntax keyword javaScriptPrototype      prototype


### PR DESCRIPTION
``` javascript
var a = {
  $label: expr
};
```

`$label` does not highlighted as a JavaScriptLabel.
I think that the label should be highlighted even if it contains $.

This pull request fixes this.
Thanks.
