### PR TITLE
Adds syntax for Identifiers in labeled statements

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -78,7 +78,7 @@ syntax region  javaScriptRegexpCharClass start=+\[+ end=+\]+ contained
 syntax region  javaScriptRegexpString   start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gimy]\{,4}+ contains=javaScriptSpecial,javaScriptRegexpCharClass,@htmlPreproc oneline
 syntax match   javaScriptNumber         /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax match   javaScriptFloat          /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
-syntax match   javaScriptLabel          /\<\w\+\(\s*:\)\@=/
+syntax match   javaScriptLabel          /\<[a-zA-Z_$][0-9a-zA-Z_$\-]*\(\s*:\)\@=/
 
 "" JavaScript Prototype
 syntax keyword javaScriptPrototype      prototype


### PR DESCRIPTION
    { $: 'now this label has syntax highlighting' }

Using this RegExp `[a-zA-Z_$][0-9a-zA-Z_$\-]` 
instead of just checking for `\w`.

Although it doesn't cover the full range of characters an Identifier
can be it does work for the 98%.
