### PR TITLE
Add new regular expression syntax groups

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -76,7 +76,7 @@ syntax region  jsRegexpCharClass start=+\[+ end=+\]+ contained
 syntax match   jsRegexpBoundary   "\v%(\<@![\^$]|\\[bB])" contained
 syntax match   jsRegexpBackRef   "\v\\[1-9][0-9]*" contained
 syntax match   jsRegexpQuantifier "\v\\@<!%([?*+]|\{\d+%(,|,\d+)?})\??" contained
-syntax match   jsRegexpOr        "\v\<@!\|"
+syntax match   jsRegexpOr        "\v\<@!\|" contained
 syntax match   jsRegexpMod       "\v\(@<=\?[:=!>]" contained
 syntax cluster jsRegexpSpecial   contains=jsRegexpBoundary,jsRegexpBackRef,jsRegexpQuantifier,jsRegexpOr,jsRegexpMod
 syntax region  jsRegexpGroup     start="\\\@<!(" matchgroup=jsRegexGroup end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial


### PR DESCRIPTION
I've been doing work to extend [vim-clojure-static](https://github.com/guns/vim-clojure-static)'s regular expression syntax and thought I might as well port over some of the work to this project since I use it. This adds new syntax for matching regular expression boundaries, back references, zero-width modifiers, quantifiers, and grouping. All new groups have been linked to `SpecialChar` with the exception of `jsRegexpGroup` which is just linked to `jsRegexString` (because linking to anything else makes things complicated).

Also, `jsSpecial` has been patched to support null and control characters. It's also been patched to drop what I'm guessing were octal escape sequences (they're deprecated AFAIK).
