### PR TITLE
Fixing multiline differentiation, fixes #77

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -79,7 +79,7 @@ endfunction
 
 " Check if the character at lnum:col is inside a multi-line comment.
 function s:IsInMultilineComment(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_multiline
+  return !IsLineComment(a:lnum, a:col) && synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_multiline
 endfunction
 
 " Check if the character at lnum:col is a line comment.


### PR DESCRIPTION
This patch is not directly mine, it is from @drslump on issue #77 - see https://github.com/pangloss/vim-javascript/issues/77#issuecomment-18255638 for details

In testing, this change works beautifully to fix #77
