### PR TITLE
Fixed single-line comment detection not recognizing line breaks as the end of the comment

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -96,7 +96,7 @@ syntax keyword jsPrototype      prototype
 syntax keyword jsSource         import export
 syntax keyword jsCommonJS       require module exports
 syntax keyword jsType           const undefined var void yield window
-syntax keyword jsOperator       delete new in instanceof let typeof prototype $
+syntax keyword jsOperator       delete new in instanceof let typeof prototype $ ø
 syntax keyword jsBoolean        true false
 
 if g:javascript_conceal == 1


### PR DESCRIPTION
I was having an issue where comment highlighting was being applied to lines following single line comments.

For example:

``` javascript
function foo(x, y) {
  // This is a comment
  return x + y;
}
```

Everything under the comment would be interpreted as a comment as well.

I just removed `\n` from the `skip` regex pattern for `jsLineComment`, and that fixed things. 
