### PR TITLE
add jsdoc tags from jsdoc v3.2-dev

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -50,7 +50,7 @@ if !exists("javascript_ignore_javaScriptdoc")
   syntax region jsDocComment      matchgroup=jsComment start="/\*\*\s*"  end="\*/" contains=jsDocTags,jsCommentTodo,jsCvsTag,@jsHtml,@Spell fold
 
   " tags containing a param
-  syntax match  jsDocTags         contained "@\(augments\|base\|borrows\|class\|constructs\|default\|defaultvalue\|emits\|exception\|exports\|extends\|file\|fires\|kind\|listens\|member\|memberOf\|methodOf\|mixes\|module\|name\|namespace\|optional\|requires\|title\|throws\|var\|variation\|version\)\>" nextgroup=jsDocParam skipwhite
+  syntax match  jsDocTags         contained "@\(alias\|augments\|base\|borrows\|class\|constructs\|default\|defaultvalue\|emits\|exception\|exports\|extends\|file\|fires\|kind\|listens\|member\|memberOf\|methodOf\|mixes\|module\|name\|namespace\|optional\|requires\|title\|throws\|var\|variation\|version\)\>" nextgroup=jsDocParam skipwhite
   " tags containing type and param
   syntax match  jsDocTags         contained "@\(arg\|argument\|param\|property\)\>" nextgroup=jsDocType skipwhite
   " tags containing type but no param
@@ -58,7 +58,7 @@ if !exists("javascript_ignore_javaScriptdoc")
   " tags containing references
   syntax match  jsDocTags         contained "@\(lends\|link\|see\)\>" nextgroup=jsDocSeeTag skipwhite
   " other tags (no extra syntax)
-  syntax match  jsDocTags         contained "@\(abstract\|access\|addon\|alias\|author\|beta\|classdesc\|constant\|const\|constructor\|copyright\|deprecated\|desc\|description\|event\|example\|exec\|field\|fileOverview\|fileoverview\|function\|global\|ignore\|inner\|instance\|license\|method\|mixin\|overview\|private\|protected\|project\|public\|readonly\|since\|static\|todo\|summary\|undocumented\|virtual\)\>"
+  syntax match  jsDocTags         contained "@\(abstract\|access\|addon\|author\|beta\|classdesc\|constant\|const\|constructor\|copyright\|deprecated\|desc\|description\|event\|example\|exec\|field\|fileOverview\|fileoverview\|function\|global\|ignore\|inner\|instance\|license\|method\|mixin\|overview\|private\|protected\|project\|public\|readonly\|since\|static\|todo\|summary\|undocumented\|virtual\)\>"
 
   syntax region jsDocType         start="{" end="}" oneline contained nextgroup=jsDocParam skipwhite
   syntax match  jsDocType         contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+" nextgroup=jsDocParam skipwhite


### PR DESCRIPTION
I also submitted pull request #83 as an alternative to this one.  Take your pick. :)

I've updated the syntax file to bring the JSDoc keywords up to date with the HEAD revision of jsdoc.

This file defines all the jsdoc tags: https://github.com/jsdoc3/jsdoc/blob/master/lib/jsdoc/tag/dictionary/definitions.js

Some keywords have been removed from jsdoc, but this pull request does NOT remove any existing keywords, in case you want to retain backwards compatibility.  I'm also submitting a separate pull request that does remove all old keywords.  Take your pick. :)

Here are the tags added:
- abstract
- callback
- classdesc
- defaultvalue
- desc
- emits
- enum
- external
- fires
- instance
- listens
- method
- mixes
- mixin
- summary
- this
- todo
- typedef
- undocumented
- var
- variation
- virtual
