### PR TITLE
add jsdoc tags from jsdoc v3.2-dev AND remove deprecated tags

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -50,7 +50,7 @@ if !exists("javascript_ignore_javaScriptdoc")
   syntax region jsDocComment      matchgroup=jsComment start="/\*\*\s*"  end="\*/" contains=jsDocTags,jsCommentTodo,jsCvsTag,@jsHtml,@Spell fold
 
   " tags containing a param
-  syntax match  jsDocTags         contained "@\(augments\|borrows\|class\|constructs\|default\|defaultvalue\|emits\|exception\|exports\|extends\|file\|fires\|kind\|listens\|member\|memberOf\|mixes\|module\|name\|namespace\|requires\|throws\|var\|variation\|version\)\>" nextgroup=jsDocParam skipwhite
+  syntax match  jsDocTags         contained "@\(alias\|augments\|borrows\|class\|constructs\|default\|defaultvalue\|emits\|exception\|exports\|extends\|file\|fires\|kind\|listens\|member\|memberOf\|mixes\|module\|name\|namespace\|requires\|throws\|var\|variation\|version\)\>" nextgroup=jsDocParam skipwhite
   " tags containing type and param
   syntax match  jsDocTags         contained "@\(arg\|argument\|param\|property\)\>" nextgroup=jsDocType skipwhite
   " tags containing type but no param
@@ -58,7 +58,7 @@ if !exists("javascript_ignore_javaScriptdoc")
   " tags containing references
   syntax match  jsDocTags         contained "@\(lends\|see\)\>" nextgroup=jsDocSeeTag skipwhite
   " other tags (no extra syntax)
-  syntax match  jsDocTags         contained "@\(abstract\|access\|alias\|author\|classdesc\|constant\|const\|constructor\|copyright\|deprecated\|desc\|description\|event\|example\|fileOverview\|function\|global\|ignore\|inner\|instance\|license\|method\|mixin\|overview\|private\|protected\|public\|readonly\|since\|static\|todo\|summary\|undocumented\|virtual\)\>"
+  syntax match  jsDocTags         contained "@\(abstract\|access\|author\|classdesc\|constant\|const\|constructor\|copyright\|deprecated\|desc\|description\|event\|example\|fileOverview\|function\|global\|ignore\|inner\|instance\|license\|method\|mixin\|overview\|private\|protected\|public\|readonly\|since\|static\|todo\|summary\|undocumented\|virtual\)\>"
 
   syntax region jsDocType         start="{" end="}" oneline contained nextgroup=jsDocParam skipwhite
   syntax match  jsDocType         contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+" nextgroup=jsDocParam skipwhite


### PR DESCRIPTION
I also submitted pull request #82 as an alternative to this one.  Take your pick. :)

I've updated the syntax file to bring the JSDoc keywords up to date with the HEAD revision of jsdoc.

This file defines all the jsdoc tags: https://github.com/jsdoc3/jsdoc/blob/master/lib/jsdoc/tag/dictionary/definitions.js

Some keywords have been removed from jsdoc, and this pull request DOES remove deprecated jsdoc keywords.  I submitted pull request #82 which does not remove any keywords.

This pull request removes these deprecated tags: 
- addon
- api
- base
- beta
- exec
- field
- fileOverview
- link
- methodOf
- optional
- project
- title

And adds these tags:
- abstract
- callback
- classdesc
- defaultvalue
- desc
- emits
- enum
- external
- fires
- instance
- listens
- method
- mixes
- mixin
- summary
- this
- todo
- typedef
- undocumented
- var
- variation
- virtual
