### PR TITLE
Fix case where line ends with [ within ( 

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -57,7 +57,7 @@ let s:msl_regex = '\%([\\*+/.:([]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)' . s:line_
 let s:one_line_scope_regex = '\<\%(if\|else\|for\|while\)\>[^{;]*' . s:line_term
 
 " Regex that defines blocks.
-let s:block_regex = '\%({\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term
+let s:block_regex = '\%([{[]\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term
 
 let s:var_stmt = '^\s*var'
 


### PR DESCRIPTION
The opening square bracket would be treated as if it were an argument to
a function call delimited by the enclosing parentheses.

This adds square brackets to the already-existing special case which
handles braces in this context.

Examples:

```
1.

    var a = [
        x

but:

    var a = ([
              x

2.

    var a = fn({ // braces already handled correctly
        x: y

    but:

    var a = fn([
                x
```
