### PR TITLE
Improve syntax highlighting

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -275,7 +275,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsNull                 Type
   HiLink jsUndefined            Type
   HiLink jsNumber               Number
-  HiLink jsFloat                Number
+  HiLink jsFloat                Float
   HiLink jsBoolean              Boolean
   HiLink jsNoise                Noise
   HiLink jsSpecial              Special


### PR DESCRIPTION
- Change `HiLink`s to be more semantically correct (according to `:help
  :hi`)
- Add `jsIdentifier`: matches any identifiers (variable names, function
  names, property names, etc)
- Add `jsFuncCall`: matches functions being called (example: matches
  `doStuff` in `var foo = bar.doStuff()`)
- Add a bunch of operators (`&&`, `>=`, `<`, `||`, `!`, etc)
- Remove `jsSource` and `jsCommonJS` - not true language features
- Add `jsUndefined` and `jsNan`
- Change `jsFunction` to a `keyword`
