### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 JavaScript bundle for vim, this bundle provides syntax and indent plugins.
 
-> Indentation of javascript in vim is terrible, and this is the very end of it.
-
-## Features
-
-1. very correct indentation for javascript
-2. support javascript indentation in html (provided by [lepture](https://github.com/lepture))
-
 ## Installation
 
 - Install with [Vundle](https://github.com/gmarik/vundle)


### PR DESCRIPTION
Removes some words about Vundle vs pathogen, we're not here to sell either.
Removes the features lines, the features are already displayed under the header.
Adds the various options you can use with this plugin
