### PR TITLE
Adds leading ternary operator indentation support

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -65,6 +65,7 @@ let s:comma_first = '^\s*,'
 let s:comma_last = ',\s*$'
 
 let s:ternary = '^\s\+[?|:]'
+let s:ternary_q = '^\s\+?'
 
 " 2. Auxiliary Functions {{{1
 " ======================
@@ -342,7 +343,7 @@ function GetJavascriptIndent()
   endif
 
   if (line =~ s:ternary)
-    if (getline(prevline) =~ s:ternary)
+    if (getline(prevline) =~ s:ternary_q)
       return indent(prevline)
     else
       return indent(prevline) + &sw


### PR DESCRIPTION
This is for the people who prefer to indent lead multiline conditional expressions with a ternary operator.

For example:

```
var x = y
  ? z
  : null
```

This block of code will now be properly indented.

Whereas before it would look like

```
var x = y
? z
: null
```
