### PR TITLE
Remove jsOpAssign

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -209,7 +209,6 @@ else
   syntax match   jsFunction       /\<function\>/ nextgroup=jsFuncName,jsFuncArgs skipwhite
 endif
 
-syntax match   jsOpAssign       /=\@<!=/ nextgroup=jsFuncBlock skipwhite skipempty
 syntax match   jsFuncName       contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=jsFuncArgs skipwhite
 syntax region  jsFuncArgs       contained matchgroup=jsFuncParens start='(' end=')' contains=jsFuncArgCommas nextgroup=jsFuncBlock keepend skipwhite
 syntax match   jsFuncArgCommas  contained ','


### PR DESCRIPTION
I believe this may be some hold over from older theme settings, and it gets in the way of jsOperator.
