### PR TITLE
A few regexpengine=1 / vim 7.3 fixes

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -93,7 +93,7 @@ syntax match   jsRegexpQuantifier "\v\\@<!%([?*+]|\{\d+%(,|,\d+)?})\??" containe
 syntax match   jsRegexpOr        "\v\<@!\|" contained
 syntax match   jsRegexpMod       "\v\(@<=\?[:=!>]" contained
 syntax cluster jsRegexpSpecial   contains=jsRegexpBoundary,jsRegexpBackRef,jsRegexpQuantifier,jsRegexpOr,jsRegexpMod
-syntax region  jsRegexpGroup     matchgroup=jsRegexGroup start="\\\@<!(" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
+syntax region  jsRegexpGroup     start="\\\@<!(" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
 syntax region  jsRegexpString    start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gimy]\{,4}+ contains=jsSpecial,jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
 syntax match   jsNumber          /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber          Infinity
@@ -246,7 +246,6 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsRegexpMod            SpecialChar
   HiLink jsRegexpBackRef        SpecialChar
   HiLink jsRegexpGroup          jsRegexpString
-  HiLink jsRegexGroup           jsRegexpString
   HiLink jsRegexpCharClass      Character
   HiLink jsCharacter            Character
   HiLink jsPrototype            Special


### PR DESCRIPTION
This commit fixes a couple general issues I found with Regexes.

Certain contained groups would break the ending of a regular expression,
causing the style to bleed out into other parts of the file. By adding
keepend we prevent the regex from leaking out.

Also, matchgroup for jsRegexpGroup must be set before start and end
definitions or else you incur bizarre highlighting behavious. This has
now been fixed.

It does not fix Vim 7.4 and the regexpengine=2 issues, however these
still are necessary fixes for all users on vim 7.3.

Also, if there is a bug in vim 7.4 with the regex engine, than most likely these fixes will apply to that 7.4 as well, whenever it gets fixed.
