### PR TITLE
Feature - Add jsFunctionKey highlight group

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -95,7 +95,7 @@ syntax match   jsNumber          /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber          Infinity
 syntax match   jsFloat           /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
 syntax match   jsObjectKey       /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\)\@=/ contains=jsFunctionKey
-syntax match   jsFunctionKey     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\sfunction\)\@=/ contained
+syntax match   jsFunctionKey     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\s*function\s*\)\@=/ contained
 
 "" JavaScript Prototype
 syntax keyword jsPrototype      prototype


### PR DESCRIPTION
This adds a higher specificity to jsObjectKeys when they define a function, as per #125 and also doesn't require a regression/removal of previous highlight groups
