### PR TITLE
Adds es6 support for rest parameters in function signatures

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -210,7 +210,7 @@ endif
 syntax match   jsFuncName       contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=jsFuncArgs skipwhite
 syntax region  jsFuncArgs       contained matchgroup=jsFuncParens start='(' end=')' contains=jsFuncArgCommas,jsFuncArgRest nextgroup=jsFuncBlock keepend skipwhite skipempty
 syntax match   jsFuncArgCommas  contained ','
-syntax match   jsFuncArgRest    contained /\.\.\.[a-zA-Z_$][0-9a-zA-Z_$]*/
+syntax match   jsFuncArgRest    contained /\%(\.\.\.[a-zA-Z_$][0-9a-zA-Z_$]*\))/
 syntax keyword jsArgsObj        arguments contained containedin=jsFuncBlock
 
 " Define the default highlighting.
@@ -223,6 +223,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   else
     command -nargs=+ HiLink hi def link <args>
   endif
+  HiLink jsFuncArgRest          Special
   HiLink jsComment              Comment
   HiLink jsLineComment          Comment
   HiLink jsEnvComment           PreProc


### PR DESCRIPTION
Will now be highlighted.

```
function x(a, ...d) {
}
```

spec: http://tc39wiki.calculist.org/es6/rest-parameters/
