### PR TITLE
Add g:javascript_indent_to_parens option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ Disables JSDoc syntax highlighting
 
 Default Value: 0
 
+#### g:javascript_indent_to_parens
+
+Aligns arguments on multi-line expressions to the opening parenthesis:
+
+    function myFunction(arg1,
+                        arg2)
+
+If set to 0, arguments are indented by one level which works better with long
+function names and if tabs are used for indentation:
+
+    function myFunction(arg1,
+        arg2)
+
+Default Value: 1
+
 ## Contributing
 
 This project uses the [git

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -25,6 +25,10 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
+if !exists('g:javascript_indent_to_parens')
+  let g:javascript_indent_to_parens = 1
+endif
+
 " 1. Variables {{{1
 " ============
 
@@ -398,7 +402,7 @@ function GetJavascriptIndent()
   if line =~ '[[({]'
     let counts = s:LineHasOpeningBrackets(lnum)
     if counts[0] == '1' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
-      if col('.') + 1 == col('$')
+      if col('.') + 1 == col('$') || g:javascript_indent_to_parens == 0
         return ind + &sw
       else
         return virtcol('.')


### PR DESCRIPTION
Added an option to allow customisation of indentation of function arguments. Rather than arguments being aligned with the opening function parenthesis (the default), arguments are indented one level extra. This works better with long function names and tabs.
