### PR TITLE
regexp: fix handling of "]" and "/" in character classes

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -90,7 +90,7 @@ syntax match   jsRegexpOr        "\v\<@!\|" contained
 syntax match   jsRegexpMod       "\v\(@<=\?[:=!>]" contained
 syntax cluster jsRegexpSpecial   contains=jsRegexpBoundary,jsRegexpBackRef,jsRegexpQuantifier,jsRegexpOr,jsRegexpMod
 syntax region  jsRegexpGroup     start="\\\@<!(" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
-syntax region  jsRegexpString    start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gimy]\{,4}+ contains=jsSpecial,jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
+syntax region  jsRegexpString    start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\.\|\[\(\\.\|[^]]\)*\]+ end=+/[gimy]\{,4}+ contains=jsSpecial,jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
 syntax match   jsNumber          /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber          Infinity
 syntax match   jsFloat           /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/


### PR DESCRIPTION
This change requires some explanation:

```
- skip=+\\\\\|\\/+
+ skip=+\\.\|\[\(\\.\|[^]]\)*\]+
```

First, `\\\\\|\\/` can be generalized to `\\.` Then, we add `\|` and follow it with a pattern to match character classes, `\[\(\\.\|[^]]\)*\]`. A character class begins with **[** and ends with **]**, so our pattern begins with `\[` and ends with `\]`. This leaves `\(\\.\|[^]]\)*`. Let us preserve our sanity by using the PCRE representation, `(\\.|[^]])*`. This group matches either:
- a backslash followed by any character*, or
- any non-**]** character.

The asterisk allows the group to match any number of times.

The secret is the `\\.`, which consumes:
- **\]** (preventing erroneous termination), and
- **\\** (preventing an escaped **\** immediately preceding a **]** from _preventing_ termination).

---

\* I assume "any" here means any character other than "\n", though I don't think the distinction is pertinent.
