### PR TITLE
Add basic support for ECMAScript 6 Template Strings

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -80,8 +80,10 @@ syntax case match
 "" Syntax in the JavaScript code
 syntax match   jsFuncCall        /\k\+\%(\s*(\)\@=/
 syntax match   jsSpecial         "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)"
+syntax match   jsTemplateVar     "\${.\{-}}"
 syntax region  jsStringD         start=+"+  skip=+\\\\\|\\$"+  end=+"+  contains=jsSpecial,@htmlPreproc
 syntax region  jsStringS         start=+'+  skip=+\\\\\|\\$'+  end=+'+  contains=jsSpecial,@htmlPreproc
+syntax region  jsTemplateString  start=+`+  skip=+\\\\\|\\$`+  end=+`+  contains=jsTemplateVar,jsSpecial,@htmlPreproc
 syntax region  jsRegexpCharClass start=+\[+ end=+\]+ contained
 syntax match   jsRegexpBoundary   "\v%(\<@![\^$]|\\[bB])" contained
 syntax match   jsRegexpBackRef   "\v\\[1-9][0-9]*" contained
@@ -181,7 +183,7 @@ endif "DOM/HTML/CSS
 
 
 "" Code blocks
-syntax cluster jsExpression contains=jsComment,jsLineComment,jsDocComment,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsGlobalObjects,jsExceptions,jsFutureKeys,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsBlock,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise
+syntax cluster jsExpression contains=jsComment,jsLineComment,jsDocComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsGlobalObjects,jsExceptions,jsFutureKeys,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsBlock,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise
 syntax cluster jsAll        contains=@jsExpression,jsLabel,jsConditional,jsRepeat,jsReturn,jsStatement,jsTernaryIf,jsException
 syntax region  jsBracket    matchgroup=jsBrackets     start="\[" end="\]" contains=@jsAll,jsParensErrB,jsParensErrC,jsBracket,jsParen,jsBlock,@htmlPreproc fold
 syntax region  jsParen      matchgroup=jsParens       start="("  end=")"  contains=@jsAll,jsParensErrA,jsParensErrC,jsParen,jsBracket,jsBlock,@htmlPreproc fold
@@ -235,6 +237,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsDocParam             Label
   HiLink jsStringS              String
   HiLink jsStringD              String
+  HiLink jsTemplateString       String
   HiLink jsTernaryIfOperator    Conditional
   HiLink jsRegexpString         String
   HiLink jsRegexpBoundary       SpecialChar
@@ -279,6 +282,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsFuncBraces           Noise
   HiLink jsFuncParens           Noise
   HiLink jsSpecial              Special
+  HiLink jsTemplateVar          Special
   HiLink jsGlobalObjects        Special
   HiLink jsExceptions           Special
   HiLink jsFutureKeys           Special


### PR DESCRIPTION
ES6 is adding support for "Template Strings", where expressions are embedded directly inside a string.  This prevents the eyesore of endless string concatenation.

Here's the spec: http://tc39wiki.calculist.org/es6/template-strings/

Here's what this constructed URL for the Flickr API looks like in vim-javascript currently:

![screenshot from 2014-02-19 20 18 10](https://f.cloud.github.com/assets/364615/2214230/3a7cf0d4-99cd-11e3-8146-74a296fc2de8.png)

This PR adds very basic support for highlighting template strings.  It makes `asdf` look like a string, and identifies ${foo} within a template string.  Here's a screenshot after this PR:

![screenshot from 2014-02-19 20 17 50](https://f.cloud.github.com/assets/364615/2214231/3a877bbc-99cd-11e3-9bdb-0563bb174e5e.png)

I don't know what your plans are for incorporating ES6 syntax changes.  Feature branch?  New repo?  Let me know, I'm happy to contribute wherever!
