### PR TITLE
Syntax highlighting for ngDocs

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -37,7 +37,7 @@ syntax keyword jsBooleanTrue    true
 syntax keyword jsBooleanFalse   false
 
 "" JavaScript comments
-syntax match jsCommentTodo    ".*\(TODO\|FIXME\|XXX\|TBD\|HACKHACK\).*" contained
+syntax match jsCommentTodo    ".*\(TODO\|FIXME\|XXX\|TBD\|HACK\).*" contained
 syntax region  jsLineComment    start=+\/\/+ end=+$+ keepend contains=jsCommentTodo,@Spell
 syntax region  jsEnvComment     start="\%^#!" end="$" display
 syntax region  jsLineComment    start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$+ keepend contains=jsCommentTodo,@Spell fold


### PR DESCRIPTION
Adds syntax highlighting for the angularjs-specific flavor of jsDocs.

Specifically:

With params:  ngdoc, methodOf, propertyOf, eventOf, link, restrict, eventType, scope, priority.
No params: animations

https://github.com/angular/angular.js/wiki/Writing-AngularJS-Documentation#wiki-the-ngdoc-directive
https://github.com/m7r/grunt-ngdocs
