### PR TITLE
regexp: add jsSpecial to jsRegexpSpecial cluster

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -79,7 +79,7 @@ syntax case match
 
 "" Syntax in the JavaScript code
 syntax match   jsFuncCall        /\k\+\%(\s*(\)\@=/
-syntax match   jsSpecial         "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)"
+syntax match   jsSpecial         "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)" contained
 syntax match   jsTemplateVar     "\${.\{-}}"
 syntax region  jsStringD         start=+"+  skip=+\\\\\|\\$"+  end=+"+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsStringS         start=+'+  skip=+\\\\\|\\$'+  end=+'+  contains=jsSpecial,@htmlPreproc,@Spell


### PR DESCRIPTION
Most significantly, this causes shorthand character classes within groups to be highlighted. For example:

``` javascript
/(\d)/
```
