### PR TITLE
Adding additional `contained`s

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -80,7 +80,7 @@ syntax case match
 "" Syntax in the JavaScript code
 syntax match   jsFuncCall        /\k\+\%(\s*(\)\@=/
 syntax match   jsSpecial         "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)" contained
-syntax match   jsTemplateVar     "\${.\{-}}"
+syntax match   jsTemplateVar     "\${.\{-}}" contained
 syntax region  jsStringD         start=+"+  skip=+\\\\\|\\$"+  end=+"+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsStringS         start=+'+  skip=+\\\\\|\\$'+  end=+'+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsTemplateString  start=+`+  skip=+\\\\\|\\$`+  end=+`+  contains=jsTemplateVar,jsSpecial,@htmlPreproc
@@ -96,7 +96,7 @@ syntax region  jsRegexpString    start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]
 syntax match   jsNumber          /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber          Infinity
 syntax match   jsFloat           /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
-syntax match   jsObjectKey       /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\)\@=/ contains=jsFunctionKey
+syntax match   jsObjectKey       /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\)\@=/ contains=jsFunctionKey contained
 syntax match   jsFunctionKey     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\s*function\s*\)\@=/ contained
 
 if g:javascript_conceal == 1


### PR DESCRIPTION
The intention of this commit is to perhaps improve performance, but also
clean up a bit of the how a couple regexes are used.

By adding `contained` to `jsObjectKey`, I think we might get a nice
performance boost, especially on larger files since it won't attemp that
lookbehind everywhere.

Adding `contained` to the newer regex for string templating stuff
in ES6 seems more 'accurate' or proper.
