### PR TITLE
Update Vundle instructions with newer Vundle plugin syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ then simply perform the following commands to fix your current buffer:
 
 Add to vimrc:
 
-    Bundle "pangloss/vim-javascript"
+    Plugin "pangloss/vim-javascript"
 
 And install it:
 
     :so ~/.vimrc
-    :BundleInstall
+    :PluginInstall
 
 ### Install with [pathogen](https://github.com/tpope/vim-pathogen)
 


### PR DESCRIPTION
Vundle now uses the `Plugin` keyword in place of the `Bundle` keyword. This
update should be reflected in the _Install with Vundle_ instructions.

See the [Vundle](https://github.com/gmarik/Vundle.vim) project on GitHub for details.
