### PR TITLE
Move `setlocal iskeyword+=$` to ftplugin/

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,0 +1,2 @@
+" Dollar sign is permitted in identifiers.
+setlocal iskeyword+=$

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -22,9 +22,6 @@ if version < 600    " Don't support the old version
   unlet! b:javascript_fold
 endif
 
-"" dollar sign is permittd anywhere in an identifier
-setlocal iskeyword+=$
-
 syntax sync fromstart
 
 syntax match   jsNoise           /\%(:\|,\|\;\|\.\)/


### PR DESCRIPTION
I'm a little hazy on the set-syntax component of vim runtime, but it
appears that the JS syntax file can be run even for non-JS filetypes,
which adds '$' to `iskeyword' everywhere.  Moving it to ftplugin/ should
fix this (and that's where it belongs, anyway).
