### PR TITLE
Fix gq to not split strings halfway through

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -15,6 +15,7 @@ setlocal nosmartindent
 
 " Now, set up our indentation expression and keys that trigger it.
 setlocal indentexpr=GetJavascriptIndent()
+setlocal formatexpr=Fixedgq(v:lnum,v:count)
 setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
 
 " Only define the function once.
@@ -437,3 +438,52 @@ endfunction
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+function! Fixedgq(lnum, count)
+    let l:count = a:count
+
+    if len(getline(a:lnum)) < 80 && l:count == 1 " No need for gq
+        return 1
+    endif
+
+    " Put all the lines on one line and do normal spliting after that
+    if l:count > 1
+        while l:count > 1
+            let l:count -= 1
+            normal J
+        endwhile
+    endif
+
+    let l:winview = winsaveview()
+
+    call cursor(a:lnum, 81)
+    let orig_breakpoint = searchpairpos(' ', '', '\.', 'bcW', '', a:lnum)
+    call cursor(a:lnum, 81)
+    let breakpoint = searchpairpos(' ', '', '\.', 'bcW', s:skip_expr, a:lnum)
+
+    " No need for special treatment, normal gq handles edgecases better
+    if breakpoint[1] == orig_breakpoint[1]
+        call winrestview(l:winview)
+        return 1
+    endif
+
+    " Try breaking after string
+    if breakpoint[1] == indent(a:lnum)
+        call cursor(a:lnum, 81)
+        let breakpoint = searchpairpos('\.', '', ' ', 'cW', s:skip_expr, a:lnum)
+    endif
+
+
+    if breakpoint[1] != 0
+        call feedkeys("r\<CR>")
+    else
+        let l:count = l:count - 1
+    endif
+
+    " run gq on new lines
+    if l:count == 1
+        call feedkeys("gqq")
+    endif
+
+    return 0
+endfunction


### PR DESCRIPTION
This pull request is based on this pullrequest https://github.com/hynek/vim-python-pep8-indent/pull/29

What it does it that it fixes gq to not split strings with spaces halfway through, which causes invalid code. I took out some stuff for docstrings, since that isn't needed for javascript.
