### PR TITLE
regexp: prevent ")" inside character class from terminating group

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -92,7 +92,7 @@ syntax match   jsRegexpQuantifier "\v\\@<!%([?*+]|\{\d+%(,|,\d+)?})\??" containe
 syntax match   jsRegexpOr        "\v\<@!\|" contained
 syntax match   jsRegexpMod       "\v\(@<=\?[:=!>]" contained
 syntax cluster jsRegexpSpecial   contains=jsSpecial,jsRegexpBoundary,jsRegexpBackRef,jsRegexpQuantifier,jsRegexpOr,jsRegexpMod
-syntax region  jsRegexpGroup     start="\\\@<!(" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
+syntax region  jsRegexpGroup     start="\\\@<!(" skip="\\.\|\[\(\\.\|[^]]\)*\]" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
 syntax region  jsRegexpString    start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\.\|\[\(\\.\|[^]]\)*\]+ end=+/[gimy]\{,4}+ contains=jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
 syntax match   jsNumber          /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber          Infinity


### PR DESCRIPTION
Commit message:

> ```
> /([)])/ is currently not handled correctly: the first ")" mistakenly
> terminates the jsRegexpGroup and consequently the jsRegexpCharClass,
> since the former contains the latter.
> 
> This commit adds a skip pattern to prevent a ")" character inside a
> character class from terminating a jsRegexpGroup.
> ```

This pattern requires some explanation:

``` vim
skip="\\.\|\[\(\\.\|[^]]\)*\]"
```

I just realized this is identical to the skip pattern added in #160! This gives me confidence in the change, and saves me from reproducing the explanation.

I first tried enhancing the skip pattern of the `jsRegexpCharClass`, but it seems a contained region cannot skip the containing region's closing delimiter.
