### PR TITLE
add js function defination syntax match

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -80,7 +80,7 @@ syntax case match
 
 "" Syntax in the JavaScript code
 syntax match   jsFuncCall        /\k\+\%(\s*(\)\@=/
-syntax match   jsFuncIdenDef     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*=\(\s*[a-zA-Z_$][0-9a-zA-Z_$]*\(\.[a-zA-Z_$][0-9a-zA-Z_$]*\)*\s*=\)*\s*function\s*(\)\@=/
+syntax match   jsFuncIdenDef     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*=\(\s*[a-zA-Z_$][0-9a-zA-Z_$]*\(\.[a-zA-Z_$][0-9a-zA-Z_$]*\)*\s*=\)*\s*function\s*(\)\@=/
 syntax match   jsSpecial         "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)" contained
 syntax match   jsTemplateVar     "\${.\{-}}" contained
 syntax region  jsStringD         start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@htmlPreproc,@Spell
@@ -98,8 +98,8 @@ syntax region  jsRegexpString    start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]
 syntax match   jsNumber          /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber          Infinity
 syntax match   jsFloat           /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
-syntax match   jsObjectKey       /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\)\@=/ contains=jsFunctionKey contained
-syntax match   jsFunctionKey     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\(\s*:\s*function\s*\)\@=/ contained
+syntax match   jsObjectKey       /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\)\@=/ contains=jsFunctionKey contained
+syntax match   jsFunctionKey     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\s*function\s*\)\@=/ contained
 
 exe 'syntax keyword jsNull      null      '.(exists('g:javascript_conceal_null')        ? 'conceal cchar='.g:javascript_conceal_null        : '')
 exe 'syntax keyword jsReturn    return    '.(exists('g:javascript_conceal_return')      ? 'conceal cchar='.g:javascript_conceal_return      : '')
@@ -175,7 +175,7 @@ endif "DOM/HTML/CSS
 
 
 "" Code blocks
-syntax cluster jsExpression contains=jsComment,jsLineComment,jsDocComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsFutureKeys,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsBlock,jsFuncCall,jsFuncDef,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsCommonJS
+syntax cluster jsExpression contains=jsComment,jsLineComment,jsDocComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsFutureKeys,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsBlock,jsFuncCall,jsFuncIdenDef,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsCommonJS
 syntax cluster jsAll        contains=@jsExpression,jsLabel,jsConditional,jsRepeat,jsReturn,jsStatement,jsTernaryIf,jsException
 syntax region  jsBracket    matchgroup=jsBrackets     start="\[" end="\]" contains=@jsAll,jsParensErrB,jsParensErrC,jsBracket,jsParen,jsBlock,@htmlPreproc fold
 syntax region  jsParen      matchgroup=jsParens       start="("  end=")"  contains=@jsAll,jsParensErrA,jsParensErrC,jsParen,jsBracket,jsBlock,@htmlPreproc fold


### PR DESCRIPTION
Hello,

I have added the _jsFuncDef_ syntax match for the function definition highlight. Because _sublime text_ highlight it that way and it is really easy to quickly grab the defined function 'name' with this highlight.

This is my work out via my [monokai](https://github.com/crusoexia/vim-monokai) color schema:
![screen shot 2014-11-29 at 12 21 12 am](https://cloud.githubusercontent.com/assets/5928754/5230297/16fbf7c0-775f-11e4-9436-4368e3350ceb.png)

Compare with sublime text 3's version:
![screen shot 2014-11-29 at 12 21 35 am](https://cloud.githubusercontent.com/assets/5928754/5230303/2dac373c-775f-11e4-9b9f-f7c01070be03.png)

And a real example:
![screen shot 2014-11-29 at 12 20 12 am](https://cloud.githubusercontent.com/assets/5928754/5230305/3d0d2c7c-775f-11e4-8747-fbc78e08f375.png)

You can checkout my [monokai](https://github.com/crusoexia/vim-monokai) scheme, use the 'dev' branch to check how it could works.

Thanks
