### PR TITLE
Fix for #34

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -49,11 +49,11 @@ let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~ '".s:syng_st
 let s:line_term = '\s*\%(\%(\/\/\).*\)\=$'
 
 " Regex that defines continuation lines, not including (, {, or [.
-let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)' . s:line_term
+let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\|[^=]=[^=].*,\)' . s:line_term
 
 " Regex that defines continuation lines.
 " TODO: this needs to deal with if ...: and so on
-let s:msl_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)' . s:line_term
+let s:msl_regex = s:continuation_regex
 
 let s:one_line_scope_regex = '\<\%(if\|else\|for\|while\)\>[^{;]*' . s:line_term
 


### PR DESCRIPTION
Fix for #34 
Regex modified to detect lines, ended with comma and containing single `=` (equals) character (not double or triple to avoid match on conditionals).
May break things if you do assignments in weird places, for example: 
```js
A = {
    B : (C = D),
        E : F,
};
```