### PR TITLE
Fixes script tag syntax for html files

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -325,6 +325,10 @@ syntax cluster  javaScriptExpression contains=@jsAll,jsBracket,jsParen,jsBlock,@
 " Vim's default html.vim highlights all javascript as 'Special'
 hi! def link javaScript              NONE
 
+" Reasert the htmlScriptTag region because otherwise html.vim treats the
+" opening <script> tag as part of the javascript region
+syntax region  htmlScriptTag     contained start=+<script+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent
+
 let b:current_syntax = "javascript"
 if main_syntax == 'javascript'
   unlet main_syntax


### PR DESCRIPTION
This has been bugging me for ages. `html.vim` seems to set a region that includes the initial `<script>` so it gets highlighted as Javascript. After messing around for a few hours, I seem to have found a fix, but I know nothing of VimL or syntax highlighting. I just kept adding stuff until it did what I wanted...

Before:

![image](https://cloud.githubusercontent.com/assets/25882/6280230/ba3fda8e-b8e4-11e4-89c0-ec8a8e4b8475.png)

After:

![image](https://cloud.githubusercontent.com/assets/25882/6280234/c3766e74-b8e4-11e4-8a20-193d0d2501ed.png)