### PR TITLE
Add dot-chaining syntax to main indent logic

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -303,7 +303,7 @@ function GetJavascriptIndent()
   " If we got a closing bracket on an empty line, find its match and indent
   " according to it.  For parentheses we indent to its column - 1, for the
   " others we indent to the containing line's MSL's level.  Return -1 if fail.
-  let col = matchend(line, '^\s*[],})]')
+  let col = matchend(line, '^\s*[],.})]')
   if col > 0 && !s:IsInStringOrComment(v:lnum, col)
     call cursor(v:lnum, col)
 


### PR DESCRIPTION
Most style guides depict chained methods to have a leading dot ans be indented on level deeper then the initial statement.

This patch adds a period as a key symbol for a nested indent. In the same fashion as the leading comma does.

It allows an indent of the following:

```javascript
var x = {
  x: 'foo',
  y: 'bar',
  z: (function() {
    return [1, 2, 3]
      .map(toFruits)
      .compact()
      .sortBy('color');
  })()
};
```

This should close issue #139.