### PR TITLE
Add `setlocal suffixesadd+=.js` to ftplugin

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,0 +1,1 @@
+setlocal suffixesadd+=.js


### PR DESCRIPTION
This suffixesadd setting helps Vim understand text that references a
path and does not contain the .js extension, as is often the case in
CommonJS style require statements. This improves motions like `gf` and
commands like `:find`. More information:

  http://usevim.com/2013/01/04/vim101-jumping/