### PR TITLE
fix GH-247: Single-line comments after import statement

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -40,7 +40,7 @@ syntax keyword jsModuleWords    default from as contained
 syntax keyword jsOf             of contained
 syntax keyword jsArgsObj        arguments
 
-syntax region jsImportContainer      start="^\s\?import \?" end="$" contains=jsModules,jsModuleWords,jsComment,jsStringS,jsStringD,jsTemplateString,jsNoise,jsBlock
+syntax region jsImportContainer      start="^\s\?import \?" end="@\(;|$\)" contains=jsModules,jsModuleWords,jsLineComment,jsComment,jsStringS,jsStringD,jsTemplateString,jsNoise,jsBlock
 
 syntax region jsExportContainer      start="^\s\?export \?" end="$" contains=jsModules,jsModuleWords,jsComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsClass,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsAssignmentExpr,jsArgsObj
 


### PR DESCRIPTION
The single line comment in the following statement is currently no
highlighted:

```js
import Y from 'Y' // this should be a comment
```

This introduces jsLineComment as being containable in an import statement,
and also closes the import statement on semicolon so that other expressions
can be highlighted correctly.