### PR TITLE
fix: import statement ending regex

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -40,7 +40,7 @@ syntax keyword jsModuleWords    default from as contained
 syntax keyword jsOf             of contained
 syntax keyword jsArgsObj        arguments
 
-syntax region jsImportContainer      start="^\s\?import \?" end="@\(;|$\)" contains=jsModules,jsModuleWords,jsLineComment,jsComment,jsStringS,jsStringD,jsTemplateString,jsNoise,jsBlock
+syntax region jsImportContainer      start="^\s\?import \?" end=";\|$" contains=jsModules,jsModuleWords,jsLineComment,jsComment,jsStringS,jsStringD,jsTemplateString,jsNoise,jsBlock
 
 syntax region jsExportContainer      start="^\s\?export \?" end="$" contains=jsModules,jsModuleWords,jsComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsClass,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsAssignmentExpr,jsArgsObj,jsBlock
 


### PR DESCRIPTION
Turns out this was broken in an earlier commit, and as a result an import region does not end.