### PR TITLE
Allow customization of line continuation indent

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -258,7 +258,9 @@ function s:IndentWithContinuation(lnum, ind, width)
   " indents an extra level.
   if s:Match(lnum, s:continuation_regex)
     if lnum == p_lnum
-      return msl_ind + a:width
+      let continuation_indent = exists('g:javascript_continuation_indent') ?
+            \ g:javascript_continuation_indent : a:width
+      return msl_ind + continuation_indent
     else
       return msl_ind
     endif


### PR DESCRIPTION
This change introduces a `g:javascript_continuation_indent` variable, which works similarly to the "+N" component of cinoptions. The default value is `&sw`, and that means that the default behavior remains unchanged.