### PR TITLE
Add option to configure arrow function conceal char

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ And install it:
 
 ### Install with [pathogen](https://github.com/tpope/vim-pathogen)
 
-      cd ~/.vim/bundle
-      git clone https://github.com/pangloss/vim-javascript.git
+      git clone https://github.com/pangloss/vim-javascript.git ~/.vim/bundle/vim-javascript
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -66,15 +66,16 @@ Default Value: 0
 You can customize concealing characters by defining one or more of the following
 variables:
 
-    let g:javascript_conceal_function   = "ƒ"
-    let g:javascript_conceal_null       = "ø"
-    let g:javascript_conceal_this       = "@"
-    let g:javascript_conceal_return     = "⇚"
-    let g:javascript_conceal_undefined  = "¿"
-    let g:javascript_conceal_NaN        = "ℕ"
-    let g:javascript_conceal_prototype  = "¶"
-    let g:javascript_conceal_static     = "•"
-    let g:javascript_conceal_super      = "Ω"
+    let g:javascript_conceal_function       = "ƒ"
+    let g:javascript_conceal_null           = "ø"
+    let g:javascript_conceal_this           = "@"
+    let g:javascript_conceal_return         = "⇚"
+    let g:javascript_conceal_undefined      = "¿"
+    let g:javascript_conceal_NaN            = "ℕ"
+    let g:javascript_conceal_prototype      = "¶"
+    let g:javascript_conceal_static         = "•"
+    let g:javascript_conceal_super          = "Ω"
+    let g:javascript_conceal_arrow_function = "⇒"
 
 ## Contributing
 

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -221,7 +221,7 @@ syntax region  jsFuncArgs       contained matchgroup=jsFuncParens start='(' end=
 syntax match   jsFuncArgCommas  contained ','
 syntax match   jsFuncArgRest    contained /\%(\.\.\.[a-zA-Z_$][0-9a-zA-Z_$]*\))/
 
-syntax match jsArrowFunction /=>/
+exe 'syntax match jsArrowFunction /=>/ '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -179,7 +179,7 @@ if exists("javascript_enable_domhtmlcss")
     syntax keyword jsCssStyles      contained border borderBottom borderLeft borderRight borderTop borderBottomColor borderLeftColor borderTopColor borderBottomStyle borderLeftStyle borderRightStyle borderTopStyle borderBottomWidth borderLeftWidth borderRightWidth borderTopWidth borderColor borderStyle borderWidth borderCollapse borderSpacing captionSide emptyCells tableLayout
     syntax keyword jsCssStyles      contained margin marginBottom marginLeft marginRight marginTop outline outlineColor outlineStyle outlineWidth padding paddingBottom paddingLeft paddingRight paddingTop
     syntax keyword jsCssStyles      contained listStyle listStyleImage listStylePosition listStyleType
-    syntax keyword jsCssStyles      contained background backgroundAttachment backgroundColor backgroundImage gackgroundPosition backgroundPositionX backgroundPositionY backgroundRepeat
+    syntax keyword jsCssStyles      contained background backgroundAttachment backgroundColor backgroundImage backgroundPosition backgroundPositionX backgroundPositionY backgroundRepeat
     syntax keyword jsCssStyles      contained clear clip clipBottom clipLeft clipRight clipTop content counterIncrement counterReset cssFloat cursor direction display filter layoutGrid layoutGridChar layoutGridLine layoutGridMode layoutGridType
     syntax keyword jsCssStyles      contained marks maxHeight maxWidth minHeight minWidth opacity MozOpacity overflow overflowX overflowY verticalAlign visibility zoom cssText
     syntax keyword jsCssStyles      contained scrollbar3dLightColor scrollbarArrowColor scrollbarBaseColor scrollbarDarkShadowColor scrollbarFaceColor scrollbarHighlightColor scrollbarShadowColor scrollbarTrackColor


### PR DESCRIPTION
For example `let g:javascript_conceal_arrow_function = "⇒"`