### PR TITLE
Make arrow-functions one-liners

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -55,7 +55,7 @@ let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\|[^=]
 " TODO: this needs to deal with if ...: and so on
 let s:msl_regex = s:continuation_regex.'|'.s:expr_case
 
-let s:one_line_scope_regex = '\<\%(if\|else\|for\|while\)\>[^{;]*' . s:line_term
+let s:one_line_scope_regex = '\%(\<\%(if\|else\|for\|while\)\>\|=>\)[^{;]*' . s:line_term
 
 " Regex that defines blocks.
 let s:block_regex = '\%([{[]\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term


### PR DESCRIPTION
Summary:
This fixes the indentation for expression arrow functions
that are continued on multiple lines.
This does not affect the `FunctionBody` variant of arrow functions,
which were already correct due to the opening brace.

Resolves pangloss/vim-javascript#332.

Test Plan:
Type
```javascript
const myNiftyArrowFunction = (foo, bar) =>
    foo + bar;
myNiftyArrowFunction(1, 2);
```
and note that it's indented correctly as you type.
Then run `gg=G` and make sure that it stays indented correctly.

Note also that the indentation of
```javascript
const myFunctionBodiedArrowFunction = (foo, bar) => {
    doAThing();
    return foo + bar;
};
myFunctionBodiedArrowFunction(1, 2);
```
is still correct.