### PR TITLE
Respect 'very-magic' in 'jsAssignmentExpr' regexp

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -110,7 +110,7 @@ syntax match   jsFunctionKey      /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\s*function
 syntax match   jsDecorator        "@" display contains=jsDecoratorFunction nextgroup=jsDecoratorFunction skipwhite
 syntax match   jsDecoratorFunction "[a-zA-Z_][a-zA-Z0-9_.]*" display contained nextgroup=jsFunc skipwhite
 
-syntax match   jsAssignmentExpr     /\v%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\(>\)\@!/ contains=jsFuncAssignExpr,jsAssignExpIdent,jsPrototype,jsOperator,jsThis,jsNoise,jsArgsObj
+syntax match   jsAssignmentExpr     /\v%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\>@!/ contains=jsFuncAssignExpr,jsAssignExpIdent,jsPrototype,jsOperator,jsThis,jsNoise,jsArgsObj
 syntax match   jsAssignExpIdent     /\v[a-zA-Z_$]\k*\ze%(\s*\=)/ contained
 syntax match   jsFuncAssignExpr     /\v%(%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\s*){-1,}\ze%(function\s*\*?\s*\()/ contains=jsFuncAssignObjChain,jsFuncAssignIdent,jsFunction,jsPrototype,jsOperator,jsThis,jsArgsObj contained
 syntax match   jsFuncAssignObjChain /\v%([a-zA-Z_$]\k*\.)+/ contains=jsPrototype,jsNoise contained


### PR DESCRIPTION
Summary:
This regex was modified in 325c0487f90707ef3e3669c1125779c7e5734037,
where the tokens `\(>\)\@!` were added.
This was supposed to be a negative lookahead for a literal `>`.
However, this didn't work because the regexp has the `\v` flag,
so the regexp actually ended up matching nothing.

Closes #333.

Test Plan:
Install the [gerw/vim-HiLinkTrace][HLT] plugin.
Write `let x = 3` in a new JavaScript file.
Place the cursor on the `x` and enter `:HLT<CR>`.
Before the patch is applied,
the `SynStack` and `HltTrace` fields of the message should be blank.
Then, apply the patch, relaunch vim, and repeat the `HLT` command;
the message should now contain `SynStack: jsAssignmentExpr->...`.

  [HLT]: https://github.com/gerw/vim-HiLinkTrace