### PR TITLE
Fix nested template variable syntax highlighting

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -88,7 +88,7 @@ syntax case match
 "" Syntax in the JavaScript code
 syntax match   jsFuncCall         /\k\+\%(\s*(\)\@=/
 syntax match   jsSpecial          "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)" contained
-syntax match   jsTemplateVar      "\${.\{-}}" contained
+syntax region  jsTemplateVar      matchgroup=jsBraces start=+${+ end=+}+ contained contains=@jsExpression
 syntax region  jsStringD          start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsStringS          start=+'+  skip=+\\\('\|$\)+  end=+'\|$+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsTemplateString   start=+`+  skip=+\\\(`\|$\)+  end=+`+     contains=jsTemplateVar,jsSpecial,@htmlPreproc


### PR DESCRIPTION
Accept JS expressions in template variables so that their contents are
highlighted normally. Change `jsTemplateVar` to a region rather than
a match.

Fixes #316 

----

Before:
<img width="427" alt="js_syntax_-_before" src="https://cloud.githubusercontent.com/assets/596174/12214729/d659768a-b654-11e5-8a81-92c4a5961a85.png">

After:
<img width="383" alt="js_syntax_-_after" src="https://cloud.githubusercontent.com/assets/596174/12214730/dabe8814-b654-11e5-8117-d089c447c3b6.png">
