### PR TITLE
fixed one line scope indent

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -66,7 +66,7 @@ let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\|[^=]
 " TODO: this needs to deal with if ...: and so on
 let s:msl_regex = s:continuation_regex.'|'.s:expr_case
 
-let s:one_line_scope_regex = '\%(\<else\>\|\<\%(if\|for\|while\)\>\s*(.*)\)' . s:line_term
+let s:one_line_scope_regex = '\%(\<else\>\|\<\%(if\|for\|while\)\>\s*([^)]*)\)' . s:line_term
 
 " Regex that defines blocks.
 let s:block_regex = '\%([{[]\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term


### PR DESCRIPTION
Continuing from #293. Fixed cases where the statement ends in parenthesis like `if(foo) bar()`