### PR TITLE
Higher specificity for jsTemplate braces

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -88,7 +88,7 @@ syntax case match
 "" Syntax in the JavaScript code
 syntax match   jsFuncCall         /\k\+\%(\s*(\)\@=/
 syntax match   jsSpecial          "\v\\%(0|\\x\x\{2\}\|\\u\x\{4\}\|\c[A-Z]|.)" contained
-syntax region  jsTemplateVar      matchgroup=jsBraces start=+${+ end=+}+ contained contains=@jsExpression
+syntax region  jsTemplateVar      matchgroup=jsTemplateBraces start=+${+ end=+}+ contained contains=@jsExpression
 syntax region  jsStringD          start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsStringS          start=+'+  skip=+\\\('\|$\)+  end=+'\|$+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsTemplateString   start=+`+  skip=+\\\(`\|$\)+  end=+`+     contains=jsTemplateVar,jsSpecial,@htmlPreproc
@@ -308,6 +308,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsClassNoise           Noise
   HiLink jsSpecial              Special
   HiLink jsTemplateVar          Special
+  HiLink jsTemplateBraces       jsBraces
   HiLink jsGlobalObjects        Special
   HiLink jsExceptions           Special
   HiLink jsFutureKeys           Special


### PR DESCRIPTION
I had the need for some more targeted syntax highlighting for template string braces, and having them namespaced to the default `jsBraces` group presented a problem.

This PR creates a new highlight group, `jsTemplateBraces`, that is then linked backed to `jsBraces` to maintain backwards compatibility.