### PR TITLE
Misc Fixes

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -218,15 +218,16 @@ exe 'syntax match jsArrowFunction /=>/ skipwhite nextgroup=jsFuncBlock contains=
 
 syntax match   jsGenerator       contained '\*' nextgroup=jsFuncName,jsFuncArgs skipwhite
 syntax match   jsFuncName        contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=jsFuncArgs skipwhite
-syntax region  jsFuncArgs        contained matchgroup=jsFuncParens start='(' end=')' contains=jsFuncArgCommas,jsFuncArgRest,jsAssignmentExpr,jsComment,jsLineComment nextgroup=jsFuncBlock keepend skipwhite skipempty
+syntax region  jsFuncArgs        contained matchgroup=jsFuncParens start='(' end=')' contains=jsFuncArgCommas,jsFuncArgRest,jsComment,jsLineComment,jsStringS,jsStringD,jsNumber,jsFuncArgDestructuring nextgroup=jsFuncBlock keepend skipwhite skipempty
 syntax match   jsFuncArgCommas   contained ','
 syntax match   jsFuncArgRest     contained /\%(\.\.\.[a-zA-Z_$][0-9a-zA-Z_$]*\))/ contains=jsFuncArgRestDots
 syntax match   jsFuncArgRestDots contained /\.\.\./
+syntax match   jsFuncArgDestructuring contained /\({\|}\|=\|:\|(\|)\)/ extend
 
 " Matches a single keyword argument with no parens
-syntax match   jsArrowFuncArgs  /\(\k\)\+\s\+\(=>\)\@=/ skipwhite contains=jsFuncArgs extend
+syntax match   jsArrowFuncArgs  /\(\k\)\+\s*\(=>\)\@=/ skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
 " Matches a series of arguments surrounded in parens
-syntax match   jsArrowFuncArgs  /(\(\k\|,\|\s\|\n\|\.\)*)\s\+\(=>\)\@=/ skipwhite contains=jsFuncArgs extend
+syntax match   jsArrowFuncArgs  /(\%(.\)*)\s*\(=>\)\@=/ skipempty skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
 
 syntax keyword jsClassKeywords extends class contained
 syntax match   jsClassNoise /\./ contained
@@ -323,6 +324,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsModuleWords          Include
   HiLink jsDecorator            Special
   HiLink jsFuncArgRestDots      Noise
+  HiLink jsFuncArgDestructuring Noise
 
   HiLink jsDomErrNo             Constant
   HiLink jsDomNodeConsts        Constant

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -196,9 +196,9 @@ syntax cluster jsExpression contains=jsComment,jsLineComment,jsBlockComment,jsTa
 syntax cluster jsAll        contains=@jsExpression,jsLabel,jsConditional,jsRepeat,jsReturn,jsStatement,jsTernaryIf,jsException
 syntax region  jsBracket    matchgroup=jsBrackets     start="\[" end="\]" contains=@jsAll,jsParensErrB,jsParensErrC,jsBracket,jsParen,jsBlock,@htmlPreproc fold
 syntax region  jsParen      matchgroup=jsParens       start="("  end=")"  contains=@jsAll,jsOf,jsParensErrA,jsParensErrC,jsParen,jsBracket,jsBlock,@htmlPreproc fold
-syntax region  jsBlock      matchgroup=jsBraces       start="{"  end="}"  contains=@jsAll,jsParensErrA,jsParensErrB,jsParen,jsBracket,jsBlock,jsObjectKey,@htmlPreproc,jsClassDefinition fold
 syntax region  jsClassBlock matchgroup=jsClassBraces  start="{"  end="}"  contains=jsFuncName,jsClassMethodDefinitions contained fold
 syntax region  jsFuncBlock  matchgroup=jsFuncBraces   start="{"  end="}"  contains=@jsAll,jsParensErrA,jsParensErrB,jsParen,jsBracket,jsBlock,@htmlPreproc,jsClassDefinition fold
+syntax region  jsBlock      matchgroup=jsBraces       start="{"  end="}"  contains=@jsAll,jsParensErrA,jsParensErrB,jsParen,jsBracket,jsBlock,jsObjectKey,@htmlPreproc,jsClassDefinition fold
 syntax region  jsTernaryIf  matchgroup=jsTernaryIfOperator start=+?+  end=+:+  contains=@jsExpression,jsTernaryIf
 
 "" catch errors caused by wrong parenthesis

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -46,11 +46,11 @@ syntax region jsExportContainer      start="^\s\?export \?" end="$" contains=jsM
 
 "" JavaScript comments
 syntax keyword jsCommentTodo    TODO FIXME XXX TBD contained
-syntax region  jsLineComment    start=+\/\/+ end=+$+ keepend contains=jsCommentTodo,@Spell
+syntax region  jsLineComment    start=+\/\/+ end=+$+ keepend contains=jsCommentTodo,@Spell extend
 syntax region  jsEnvComment     start="\%^#!" end="$" display
 syntax region  jsLineComment    start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$+ keepend contains=jsCommentTodo,@Spell fold
 syntax region  jsCvsTag         start="\$\cid:" end="\$" oneline contained
-syntax region  jsComment        start="/\*"  end="\*/" contains=jsCommentTodo,jsCvsTag,@Spell fold
+syntax region  jsComment        start="/\*"  end="\*/" contains=jsCommentTodo,jsCvsTag,@Spell fold extend
 
 "" JSDoc / JSDoc Toolkit
 if !exists("javascript_ignore_javaScriptdoc")


### PR DESCRIPTION
This PR is a few fixes we should get into `develop` before merging `develop` into `master`.

**Fixed Comment Regions**
* Fixed comment regions by adding the extend keyword (this means they override containing region endpoints, which they do when it comes to actual code. Before this PR, if you created a block comment inside say an object, with no closing block comment, the comment would appear to end at the end of the object. This is obviously not how block comments work.

![oops](https://dl.dropboxusercontent.com/s/6ypjsthypvxupix/file.js_2016-04-05_17-34-23.png?dl=0)

**Function Argument Declaration Destructuring Improvements**
* Some small improvements to destructuring in function declarations. This is far from complete, but a bit better than it used to be and handles many standard cases (I hope)

![yay](https://dl.dropboxusercontent.com/s/or8rbe0l9vvwvpr/file.js_2016-04-05_17-42-47.png?dl=0)

**Fixed `jsBlock` vs `jsFuncBlock` priority in top level code**
* Before this PR, if you wrote an object at the top level of a file (i.e. not contained in a function or object or something), the braces would detect as `jsFuncBlock`. This bug was introduced from my earlier updates to arrow functions. The simple fix for this was to make `jsBlock` higher priority. `jsFuncBlock` continues to work normally in other contexts because specifiers like `nextgroup=` take priority.

![oops2](https://dl.dropboxusercontent.com/s/f1oosdsk92u7oks/file.js_2016-04-05_17-40-15.png?dl=0)

### Note
We still have a major issue with arrow function declarations - allowing the argument parenthesis to span multiple lines. This is actually quite a challenging regex problem, and I don't think I will be able to come up with a fix in a reasonable amount of time and think we should ship the current `develop` branch with these fixes asap since there's a lot of great stuff in there.