### PR TITLE
Improve one line scope

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -66,7 +66,7 @@ let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\|[^=]
 " TODO: this needs to deal with if ...: and so on
 let s:msl_regex = s:continuation_regex.'\|'.s:expr_case
 
-let s:one_line_scope_regex = '\%(\%(\<else\>\|\<\%(if\|for\|while\)\>\s*(.*)\)\|=>\)' . s:line_term
+let s:one_line_scope_regex = '\%(\%(\<else\>\|\<\%(if\|for\|while\)\>\s*(\%([^()]*\|[^()]*(\%([^()]*\|[^()]*(\%([^()]*\|[^()]*([^()]*)[^()]*\))[^()]*\))[^()]*\))\)\|=>\)' . s:line_term
 
 " Regex that defines blocks.
 let s:block_regex = '\%([{[]\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term


### PR DESCRIPTION
#293
this will detect the start and end parentheses after 'if,for,while',allowing statements with parentheses to come after the condition parens.This regex can detect with up to 4 levels of nesting.