### PR TITLE
Fix arrow function parens arguments

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -227,7 +227,7 @@ syntax match   jsFuncArgDestructuring contained /\({\|}\|=\|:\|(\|)\)/ extend
 " Matches a single keyword argument with no parens
 syntax match   jsArrowFuncArgs  /\(\k\)\+\s*\(=>\)\@=/ skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
 " Matches a series of arguments surrounded in parens
-syntax match   jsArrowFuncArgs  /(\%(.\)*)\s*\(=>\)\@=/ skipempty skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
+syntax match   jsArrowFuncArgs  /(\%(.)\)*)\s*\(=>\)\@=/ skipempty skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
 
 syntax keyword jsClassKeywords extends class contained
 syntax match   jsClassNoise /\./ contained


### PR DESCRIPTION
The syntax highlighter showed error when arrow functions had parentheses surrounding their arugemnts:
```javascript
...
  .then((result) => {
      send(result);
  })
--^ // The last parenthesis of `then` method call was considered excess.
``` 
I fixed the regex for args in parenthesis and it seems it works. I'm using it right now.

As seen in #374 :)