### PR TITLE
Temporarily disabled jsArrowFuncArgs with parens

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -227,7 +227,7 @@ syntax match   jsFuncArgDestructuring contained /\({\|}\|=\|:\|(\|)\|\[\|\]\)/ e
 " Matches a single keyword argument with no parens
 syntax match   jsArrowFuncArgs  /\(\k\)\+\s*\(=>\)\@=/ skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
 " Matches a series of arguments surrounded in parens
-syntax match   jsArrowFuncArgs  /(\%(.\)*)\s*\(=>\)\@=/ skipempty skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
+" syntax match   jsArrowFuncArgs  /(\%(.\)*)\s*\(=>\)\@=/ skipempty skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction
 
 syntax keyword jsClassKeywords extends class contained
 syntax match   jsClassNoise /\./ contained


### PR DESCRIPTION
This is until we can figure out how to properly match all the crazy use
cases.

This should at least make issues #364 and #378 not appear as errors.