### PR TITLE
Support comments in ES6 classes

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -196,7 +196,7 @@ syntax cluster jsExpression contains=jsComment,jsLineComment,jsBlockComment,jsTa
 syntax cluster jsAll        contains=@jsExpression,jsLabel,jsConditional,jsRepeat,jsReturn,jsStatement,jsTernaryIf,jsException
 syntax region  jsBracket    matchgroup=jsBrackets     start="\[" end="\]" contains=@jsAll,jsParensErrB,jsParensErrC,jsBracket,jsParen,jsBlock,@htmlPreproc fold
 syntax region  jsParen      matchgroup=jsParens       start="("  end=")"  contains=@jsAll,jsOf,jsParensErrA,jsParensErrC,jsParen,jsBracket,jsBlock,@htmlPreproc fold
-syntax region  jsClassBlock matchgroup=jsClassBraces  start="{"  end="}"  contains=jsFuncName,jsClassMethodDefinitions contained fold
+syntax region  jsClassBlock matchgroup=jsClassBraces  start="{"  end="}"  contains=jsComment,jsLineComment,jsBlockComment,jsFuncName,jsClassMethodDefinitions contained fold
 syntax region  jsFuncBlock  matchgroup=jsFuncBraces   start="{"  end="}"  contains=@jsAll,jsParensErrA,jsParensErrB,jsParen,jsBracket,jsBlock,@htmlPreproc,jsClassDefinition fold
 syntax region  jsBlock      matchgroup=jsBraces       start="{"  end="}"  contains=@jsAll,jsParensErrA,jsParensErrB,jsParen,jsBracket,jsBlock,jsObjectKey,@htmlPreproc,jsClassDefinition fold
 syntax region  jsTernaryIf  matchgroup=jsTernaryIfOperator start=+?+  end=+:+  contains=@jsExpression,jsTernaryIf


### PR DESCRIPTION
I noticed a bug with syntax highlighting of comments inside ES6 classes:

<img width="125" alt="screen shot 2016-04-19 at 1 45 40 pm" src="https://cloud.githubusercontent.com/assets/3929133/14649458/0f9de9dc-0635-11e6-90d8-d16588d10b04.png">
<img width="123" alt="screen shot 2016-04-19 at 1 45 51 pm" src="https://cloud.githubusercontent.com/assets/3929133/14649456/0f9d44be-0635-11e6-80a2-84a872098623.png">

This was "introduced" since class support #354, which have a very strict definition (not including `@jsAll`).

This PR adds support for comments inside ES6 classes:

<img width="127" alt="screen shot 2016-04-19 at 1 50 05 pm" src="https://cloud.githubusercontent.com/assets/3929133/14649622/ebc2801c-0635-11e6-92e9-23b389c26171.png">
<img width="184" alt="screen shot 2016-04-19 at 1 50 16 pm" src="https://cloud.githubusercontent.com/assets/3929133/14649623/ebc311ee-0635-11e6-931c-bfc05d7627eb.png">
