### PR TITLE
Adding a license note to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ proposed change and how it is valuable.
 ## Bug report
 
 Report a bug on [GitHub Issues](https://github.com/pangloss/vim-javascript/issues).
+
+## License
+
+Distributed under the same terms as Vim itself. See `:help license`.


### PR DESCRIPTION
I basically just copied what Tim Pope has done for his projects, an
example can be seen here:

[vim-pathogen#license](https://github.com/tpope/vim-pathogen#license)