### PR TITLE
spanning multiple lines detection

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -145,9 +145,21 @@ function s:GetMSL(lnum, in_one_line_scope)
     " Otherwise, terminate search as we have found our MSL already.
     let line = getline(lnum)
     let col = match(line, s:msl_regex) + 1
+    let line2 = getline(msl)
+    let col2 = matchend(line2, ')')
     if (col > 0 && !s:IsInStringOrComment(lnum, col)) || s:IsInString(lnum, strlen(line))
       let msl = lnum
+
+    " if there are more closing brackets, continue from the line which has the matching opening bracket
+    elseif col2 > 0 && !s:IsInStringOrComment(msl, col2) && s:LineHasOpeningBrackets(msl)[0] == '2'
+      call cursor(msl, 1)
+      if searchpair('(', '', ')', 'bW', s:skip_expr) > 0
+        let lnum = line('.')
+        let msl = lnum
+      endif
+
     else
+
       " Don't use lines that are part of a one line scope as msl unless the
       " flag in_one_line_scope is set to 1
       "
@@ -158,7 +170,7 @@ function s:GetMSL(lnum, in_one_line_scope)
       if msl_one_line == 0
         break
       endif
-    endif
+    end
     let lnum = s:PrevNonBlankNonString(lnum - 1)
   endwhile
   return msl
@@ -396,7 +408,7 @@ function GetJavascriptIndent()
       return indent(prevline) + s:sw()
     end
     " If previous line starts with an operator...
-  elseif s:Match(prevline, s:operator_first) && !s:Match(prevline, s:comma_last)
+  elseif s:Match(prevline, s:operator_first) && !s:Match(prevline, s:comma_last) && !s:Match(prevline, '};\=' . s:line_term)
     let counts = s:LineHasOpeningBrackets(prevline)
     if counts[0] == '2' && counts[1] == '1'
       call cursor(prevline, 1)
@@ -472,7 +484,14 @@ function GetJavascriptIndent()
     else
       call cursor(v:lnum, vcol)
     end
-  elseif line =~ ')' || line =~ s:comma_last
+  elseif line =~ '.\+};\=' . s:line_term
+    call cursor(lnum, 1)
+    " Search for the opening tag
+    let mnum = searchpair('{', '', '}', 'bW', s:skip_expr)
+    if mnum > 0
+      return indent(s:GetMSL(mnum, 0)) 
+    end
+  elseif line =~ '.\+);\=' || line =~ s:comma_last
     let counts = s:LineHasOpeningBrackets(lnum)
     if counts[0] == '2'
       call cursor(lnum, 1)
@@ -481,7 +500,7 @@ function GetJavascriptIndent()
       if mnum > 0
         return indent(s:GetMSL(mnum, 0)) 
       end
-    elseif  line !~ s:var_stmt
+    elseif line !~ s:var_stmt
       return indent(prevline)
     end
   end


### PR DESCRIPTION
here are the effects, I made sure performance wasn't affected.
Also this has nothing to do with the operators this just illustrates the problem
```

if ( a == b
    && c == d
    && e == f
    || g == h
    || i == j ) {
  a = b
    + c
    - d;
}
```
as opposed to this which would indent everything following it:
```

if ( a == b
    && c == d
    && e == f
    || g == h
    || i == j ) {
  a = b
    + c
    - d;
    }
```