### PR TITLE
Performance Improvements

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -124,8 +124,7 @@ syntax keyword jsKeyword        yield
 syntax keyword jsException      try catch throw finally
 syntax keyword jsAsyncKeyword   async await
 
-syntax keyword jsGlobalObjects   Array Boolean Date Function Iterator Number Object Symbol Map WeakMap Set RegExp String Proxy Promise Buffer ParallelArray ArrayBuffer DataView Float32Array Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array Uint8Array Uint8ClampedArray Intl JSON Math console document window
-syntax match   jsGlobalObjects  /\%(Intl\.\)\@<=\(Collator\|DateTimeFormat\|NumberFormat\)/
+syntax keyword jsGlobalObjects   Array Boolean Date Function Iterator Number Object Symbol Map WeakMap Set RegExp String Proxy Promise Buffer ParallelArray ArrayBuffer DataView Float32Array Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array Uint8Array Uint8ClampedArray JSON Math console document window Intl Collator DateTimeFormat NumberFormat
 
 syntax keyword jsExceptions     Error EvalError InternalError RangeError ReferenceError StopIteration SyntaxError TypeError URIError
 

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -36,7 +36,7 @@ syntax keyword jsArgsObj        arguments
 
 syntax region jsImportContainer      start="^\s\?import \?" end=";\|$" contains=jsModules,jsModuleWords,jsLineComment,jsComment,jsStringS,jsStringD,jsTemplateString,jsNoise,jsBlock
 
-syntax region jsExportContainer      start="^\s\?export \?" end="$" contains=jsModules,jsModuleWords,jsComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsAssignmentExpr,jsArgsObj,jsBlock,jsClassDefinition
+syntax region jsExportContainer      start="^\s\?export \?" end="$" contains=jsModules,jsModuleWords,jsComment,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsArgsObj,jsBlock,jsClassDefinition
 
 "" JavaScript comments
 syntax keyword jsCommentTodo    TODO FIXME XXX TBD contained
@@ -105,12 +105,6 @@ syntax match   jsObjectKey        /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\)\@=/ cont
 syntax match   jsFunctionKey      /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\s*function\s*\)\@=/ contained
 syntax match   jsDecorator        "@" display contains=jsDecoratorFunction nextgroup=jsDecoratorFunction skipwhite
 syntax match   jsDecoratorFunction "[a-zA-Z_][a-zA-Z0-9_.]*" display contained nextgroup=jsFunc skipwhite
-
-syntax match   jsAssignmentExpr     /\v%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\>@!/ contains=jsFuncAssignExpr,jsAssignExpIdent,jsPrototype,jsOperator,jsThis,jsNoise,jsArgsObj
-syntax match   jsAssignExpIdent     /\v[a-zA-Z_$]\k*\ze%(\s*\=)/ contained
-syntax match   jsFuncAssignExpr     /\v%(%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\s*){-1,}\ze%(function\s*\*?\s*\()/ contains=jsFuncAssignObjChain,jsFuncAssignIdent,jsFunction,jsPrototype,jsOperator,jsThis,jsArgsObj contained
-syntax match   jsFuncAssignObjChain /\v%([a-zA-Z_$]\k*\.)+/ contains=jsPrototype,jsNoise contained
-syntax match   jsFuncAssignIdent    /\v[a-zA-Z_$]\k*\ze%(\s*\=)/ contained
 
 exe 'syntax keyword jsNull      null      '.(exists('g:javascript_conceal_null')        ? 'conceal cchar='.g:javascript_conceal_null        : '')
 exe 'syntax keyword jsReturn    return    '.(exists('g:javascript_conceal_return')      ? 'conceal cchar='.g:javascript_conceal_return      : '')
@@ -188,7 +182,7 @@ endif "DOM/HTML/CSS
 "" end DOM/HTML/CSS specified things
 
 "" Code blocks
-syntax cluster jsExpression contains=jsComment,jsLineComment,jsBlockComment,jsTaggedTemplate,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsStatic,jsSuper,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsFutureKeys,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsBlock,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsCommonJS,jsAssignmentExpr,jsImportContainer,jsExportContainer,jsArgsObj,jsDecorator,jsAsyncKeyword,jsClassDefinition,jsArrowFunction,jsArrowFuncArgs
+syntax cluster jsExpression contains=jsComment,jsLineComment,jsBlockComment,jsTaggedTemplate,jsTemplateString,jsStringD,jsStringS,jsRegexpString,jsNumber,jsFloat,jsThis,jsStatic,jsSuper,jsOperator,jsBooleanTrue,jsBooleanFalse,jsNull,jsFunction,jsArrowFunction,jsGlobalObjects,jsExceptions,jsFutureKeys,jsDomErrNo,jsDomNodeConsts,jsHtmlEvents,jsDotNotation,jsBracket,jsParen,jsBlock,jsFuncCall,jsUndefined,jsNan,jsKeyword,jsStorageClass,jsPrototype,jsBuiltins,jsNoise,jsCommonJS,jsImportContainer,jsExportContainer,jsArgsObj,jsDecorator,jsAsyncKeyword,jsClassDefinition,jsArrowFunction,jsArrowFuncArgs
 syntax cluster jsAll        contains=@jsExpression,jsLabel,jsConditional,jsRepeat,jsReturn,jsStatement,jsTernaryIf,jsException
 syntax region  jsBracket    matchgroup=jsBrackets     start="\[" end="\]" contains=@jsAll,jsParensErrB,jsParensErrC,jsBracket,jsParen,jsBlock,@htmlPreproc fold
 syntax region  jsParen      matchgroup=jsParens       start="("  end=")"  contains=@jsAll,jsOf,jsParensErrA,jsParensErrC,jsParen,jsBracket,jsBlock,@htmlPreproc fold extend

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -196,12 +196,6 @@ syntax match   jsParensErrA     contained "\]"
 syntax match   jsParensErrB     contained ")"
 syntax match   jsParensErrC     contained "}"
 
-if main_syntax == "javascript"
-  syntax sync clear
-  syntax sync ccomment jsComment minlines=200
-  syntax sync match jsHighlight grouphere jsBlock /{/
-endif
-
 syntax match   jsFuncArgDestructuring contained /\({\|}\|=\|:\|\[\|\]\)/ extend
 exe 'syntax match jsFunction /\<function\>/ nextgroup=jsGenerator,jsFuncName,jsFuncArgs skipwhite '.(exists('g:javascript_conceal_function') ? 'conceal cchar='.g:javascript_conceal_function : '')
 exe 'syntax match jsArrowFunction /=>/ skipwhite nextgroup=jsFuncBlock contains=jsFuncBraces '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -97,7 +97,7 @@ syntax match   jsRegexpOr         "\v\<@!\|" contained
 syntax match   jsRegexpMod        "\v\(@<=\?[:=!>]" contained
 syntax cluster jsRegexpSpecial    contains=jsSpecial,jsRegexpBoundary,jsRegexpBackRef,jsRegexpQuantifier,jsRegexpOr,jsRegexpMod
 syntax region  jsRegexpGroup      start="\\\@<!(" skip="\\.\|\[\(\\.\|[^]]\)*\]" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
-syntax region  jsRegexpString     start=+\%(\%(\%(return\|case\)\s\+\)\@<=\|\%(\%([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\.\|\[\%(\\.\|[^]]\)*\]+ end=+/[gimy]\{,4}+ contains=jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
+syntax region  jsRegexpString     start=+\%(\%(\%(return\|case\)\s\+\)\@50<=\|\%(\%([)\]"']\|\d\|\w\)\s*\)\@50<!\)/\(\*\|/\)\@!+ skip=+\\.\|\[\%(\\.\|[^]]\)*\]+ end=+/[gimy]\{,4}+ contains=jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
 syntax match   jsNumber           /\<-\=\d\+\(L\|[eE][+-]\=\d\+\)\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber           Infinity
 syntax match   jsFloat            /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -21,12 +21,12 @@ setlocal iskeyword+=$
 
 syntax sync fromstart
 
-syntax match   jsNoise           /\%(:\|,\|\;\|\.\)/
+syntax match   jsNoise           /[:,\;\.]\{1}/
 
 "" Program Keywords
 syntax keyword jsStorageClass   const var let
 syntax keyword jsOperator       delete instanceof typeof void new in
-syntax match   jsOperator       /\(!\||\|&\|+\|-\|<\|>\|=\|%\|\/\|*\|\~\|\^\)/
+syntax match   jsOperator       /[\!\|\&\+\-\<\>\=\%\/\*\~\^]\{1}/
 syntax keyword jsBooleanTrue    true
 syntax keyword jsBooleanFalse   false
 syntax keyword jsModules        import export contained

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -214,7 +214,7 @@ syntax match   jsFuncArgRest     contained /\%(\.\.\.[a-zA-Z_$][0-9a-zA-Z_$]*\))
 syntax match   jsFuncArgRestDots contained /\.\.\./
 
 " Matches a single keyword argument with no parens
-syntax match   jsArrowFuncArgs  /\(\k\)\+\s*\(=>\)\@=/ skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction extend
+syntax match   jsArrowFuncArgs  /\k\+\s*\%(=>\)\@=/ skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction extend
 " Matches a series of arguments surrounded in parens
 syntax match   jsArrowFuncArgs  /([^()]*)\s*\(=>\)\@=/ skipempty skipwhite contains=jsFuncArgs nextgroup=jsArrowFunction extend
 

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -97,7 +97,7 @@ syntax match   jsRegexpOr         "\v\<@!\|" contained
 syntax match   jsRegexpMod        "\v\(@<=\?[:=!>]" contained
 syntax cluster jsRegexpSpecial    contains=jsSpecial,jsRegexpBoundary,jsRegexpBackRef,jsRegexpQuantifier,jsRegexpOr,jsRegexpMod
 syntax region  jsRegexpGroup      start="\\\@<!(" skip="\\.\|\[\(\\.\|[^]]\)*\]" end="\\\@<!)" contained contains=jsRegexpCharClass,@jsRegexpSpecial keepend
-syntax region  jsRegexpString     start=+\(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\.\|\[\(\\.\|[^]]\)*\]+ end=+/[gimy]\{,4}+ contains=jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
+syntax region  jsRegexpString     start=+\%(\%(\%(return\|case\)\s\+\)\@<=\|\%(\%([)\]"']\|\d\|\w\)\s*\)\@<!\)/\(\*\|/\)\@!+ skip=+\\.\|\[\%(\\.\|[^]]\)*\]+ end=+/[gimy]\{,4}+ contains=jsRegexpCharClass,jsRegexpGroup,@jsRegexpSpecial,@htmlPreproc oneline keepend
 syntax match   jsNumber           /\<-\=\d\+\(L\|[eE][+-]\=\d\+\)\=\>\|\<0[xX]\x\+\>/
 syntax keyword jsNumber           Infinity
 syntax match   jsFloat            /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -88,7 +88,7 @@ syntax region  jsTemplateVar      matchgroup=jsTemplateBraces start=+${+ end=+}+
 syntax region  jsStringD          start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsStringS          start=+'+  skip=+\\\('\|$\)+  end=+'\|$+  contains=jsSpecial,@htmlPreproc,@Spell
 syntax region  jsTemplateString   start=+`+  skip=+\\\(`\|$\)+  end=+`+     contains=jsTemplateVar,jsSpecial,@htmlPreproc
-syntax region  jsTaggedTemplate   start=/\k\+\(\(\n\|\s\)\+\)\?`/ end=+`+ contains=jsTemplateString keepend
+syntax region  jsTaggedTemplate   start=/\k\+\%([\n\s]\+\)\?`/ end=+`+ contains=jsTemplateString keepend
 syntax region  jsRegexpCharClass  start=+\[+ skip=+\\.+ end=+\]+ contained
 syntax match   jsRegexpBoundary   "\v%(\<@![\^$]|\\[bB])" contained
 syntax match   jsRegexpBackRef    "\v\\[1-9][0-9]*" contained


### PR DESCRIPTION
I recently learned a bit about the `:syntime` command, and decided to use it to profile our syntax file. I've found some things that I think we can really optimize and I actually got some fairly significant optimizations just in this PR.

I am using a fully compiled version of [PhaserJS](https://raw.githubusercontent.com/photonstorm/phaser/dev/build/phaser.js) for these benchmarks. I think it's safe to say it's a huge file and I considered it a good way to benchmark performance. As an aside, if there are files you find performance to be pretty bad, you should link it here so I can run these benchmarks and look for other optimizations.

The steps to reproduce the tests are as follows

1. Open the `phaser.js` file
2. Press `gg` to scroll to the top (I would additionally do `:set nowrap` as well)
3. Start the syntax profiler: `:syntime on`
4. Scroll quickly to around line 10,000 (I could've gone further, but I found it to be a pretty healthy test time)
5. Get the profiles results using `:syntime report`

Here are before and after results for the most intensive selectors:

## Before
```
TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN
1.617329   62434  0       0.002201    0.000026  jsGlobalObjects    \%(Intl\.\)\@<=\(Collator\|DateTimeFormat\|
1.047933   19970  2490    0.002397    0.000052  jsFuncAssignExpr   \v%(%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\s
1.028959   147679 93522   0.002242    0.000007  jsOperator         \(!\||\|&\|+\|-\|<\|>\|=\|%\|\/\|*\|\~\|\^\
0.977351   69643  10656   0.002030    0.000014  jsRegexpString     \(\(\(return\|case\)\s\+\)\@<=\|\(\([)\]"']
0.932609   62434  0       0.002367    0.000015  jsArrowFuncArgs    \(\k\)\+\s*\(=>\)\@=
0.930731   109058 49930   0.003152    0.000009  jsFuncCall         \k\+\%(\s*(\)\@=
0.701920   97547  35215   0.001612    0.000007  jsAssignmentExpr   \v%([a-zA-Z_$]\k*\.)*[a-zA-Z_$]\k*\s*\=\>@!
0.513394   192983 163196   0.001123   0.000003  jsNoise            \%(:\|,\|\;\|\.\)
0.439069   62434  0       0.001627    0.000007  jsTaggedTemplate   \k\+\(\(\n\|\s\)\+\)\?`
0.398041   103527 40664   0.001752    0.000004  jsNumber           \<-\=\d\+\(L\|[eE][+-]\=\d\+\)\=\>\|\<0[xX]
0.205140   63112  687     0.001655    0.000003  jsFloat            \<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE]
0.189091   40580  23100   0.002135    0.000005  jsAssignExpIdent   \v[a-zA-Z_$]\k*\ze%(\s*\=)
0.140040   35583  3553    0.001768    0.000004  jsDocTags          @\(abstract\|access\|accessor\|author\|clas
0.132321   20175  1427    0.001212    0.000007  jsObjectKey        \<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\)\@=
0.089218   63451  2689    0.001222    0.000001  jsLineComment      ^\s*\/\/       
```

## After
```
TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN
0.887965   68688  12559   0.002036    0.000013  jsRegexpString     \%(\%(\%(return\|case\)\s\+\)\@<=\|\%(\%([)\]"']\|\d\|\w
0.855625   109576 53343   0.002364    0.000008  jsFuncCall         \k\+\%(\s*(\)\@=
0.671938   59407  0       0.002029    0.000011  jsArrowFuncArgs    \k\+\s*\%(=>\)\@=
0.379020   137695 86113   0.001926    0.000003  jsOperator         [\!\|\&\+\-\<\>\=\%\/\*\~\^]\{1}
0.376395   101537 41691   0.001237    0.000004  jsNumber           \<-\=\d\+\(L\|[eE][+-]\=\d\+\)\=\>\|\<0[xX]\x\+\>
0.295642   59407  0       0.002014    0.000005  jsTaggedTemplate   \k\+\%([\n\s]\+\)\?`
0.284822   181546 152855   0.001993   0.000002  jsNoise            [:,\;\.]\{1}
0.194653   60391  991     0.001991    0.000003  jsFloat            \<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\
0.139054   21099  1720    0.002092    0.000007  jsObjectKey        \<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\)\@=
0.128952   35864  3521    0.002004    0.000004  jsDocTags          @\(abstract\|access\|accessor\|author\|classdesc\|consta
0.093106   60401  2413    0.001991    0.000002  jsLineComment      ^\s*\/\/
```

In summary, I found a few rules that seem to be just hanging around not matching anything (probably from a bygone era of function matching) that could easily be removed and also found a few ways to optimize a few of the hotter important contenders.

I am open to more optimization suggestions if you guys have them! I will let this sit for a bit though, to ensure I haven't really broken anything, but so far everything seems very solid.