### PR TITLE
Fix jsDocParam

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -77,7 +77,7 @@ if !exists("javascript_ignore_javaScriptdoc")
   syntax match  jsDocType         contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+" nextgroup=jsDocParam skipwhite
   syntax region jsDocTypeNoParam  start="{" end="}" oneline contained
   syntax match  jsDocTypeNoParam  contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+"
-  syntax match  jsDocParam        contained "\%(#\|\$\|-\|'\|\"\|{\|}\|\w\|\.\|:\|\/\|\[\|]\|=\)\+"
+  syntax match  jsDocParam        contained "\%(#\|\$\|-\|'\|\"\|{.\{-}}\|\w\|\.\|:\|\/\|\[.{-}]\|=\)\+"
   syntax region jsDocSeeTag       contained matchgroup=jsDocSeeTag start="{" end="}" contains=jsDocTags
 
   syntax case match


### PR DESCRIPTION
I am not sure exactly why this problem exists, but it causes some weird side effects.

Before this commit:
![before](http://wtf.amadeus.wtf/js-doc-broken.png)

After this commit:
![after](http://wtf.amadeus.wtf/js-doc-fixed.png)

The arrows point out the syntax errors, and there's a deeper problem. If you use `%` on the opening `{` of the function, it will match with the second `}` in the comment. It should of course match the final closing `}` of the function.

The fix I have for it, is to only match on paired opening and closing curly brackets. I have not noticed any issues to existing JSDoc comments.