### PR TITLE
Forcing `class` text to be a keyword

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -222,7 +222,7 @@ syntax match   jsArrowFuncArgs  /([^()]*)\s*\(=>\)\@=/ skipempty skipwhite conta
 syntax keyword jsClassKeywords extends class contained
 syntax match   jsClassNoise /\./ contained
 syntax keyword jsClassMethodDefinitions get set static contained nextgroup=jsFuncName skipwhite skipempty
-syntax match   jsClassDefinition /class\%( [a-zA-Z_$][0-9a-zA-Z_$ \n.]*\)*/  contains=jsClassKeywords,jsClassNoise nextgroup=jsClassBlock skipwhite skipempty
+syntax match   jsClassDefinition /\<class\>\%( [a-zA-Z_$][0-9a-zA-Z_$ \n.]*\)*/  contains=jsClassKeywords,jsClassNoise nextgroup=jsClassBlock skipwhite skipempty
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already


### PR DESCRIPTION
This class regex will match if the text class is contained within a larger variable name, and therefore is broken.

I.E. In a definition for `className`, `class` will match as `jsClassDefinition` which is bad.

This P.R. fixes that by forcing `class` to be a keyword.