### PR TITLE
Shebang doesn't have to contain env

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -3,7 +3,7 @@ au BufNewFile,BufRead *.jsm setf javascript
 au BufNewFile,BufRead Jakefile setf javascript
 
 fun! s:SelectJavascript()
-  if getline(1) =~# '^#!.*/bin/env\s\+node\>'
+  if getline(1) =~# '^#!.*/bin/\%(env\s\+\)\?node\>'
     set ft=javascript
   endif
 endfun


### PR DESCRIPTION
Skimming our neighbor's ( [vim-javascript-syntax](https://github.com/jelera/vim-javascript-syntax) ) commits saw this one. added `\%(\)` group catching to perform a little bit faster.