### PR TITLE
readability changes in the indent script

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -119,10 +119,8 @@ endfunction
 function s:PrevNonBlankNonString(lnum)
   let lnum = prevnonblank(a:lnum)
   while lnum > 0
-    " Go in and out of blocks comments as necessary.
-    " If the line isn't empty (with opt. comment) or in a string, end search.
     let line = getline(lnum)
-    let com = match(line, '\*\/') + 1
+    let com = match(line, '\*/') + 1
     if s:IsInMultilineComment(lnum, com)
       call cursor(lnum, com)
       let parlnum = search('/\*', 'nbW')
@@ -358,6 +356,7 @@ function GetJavascriptIndent()
   endif
 
   let lnum = s:PrevNonBlankNonString(v:lnum - 1)
+
   " If line starts with an operator...
   if (line =~ s:operator_first)
     if (s:Match(lnum, s:operator_first))
@@ -429,8 +428,8 @@ function GetJavascriptIndent()
   " add indent depending on the bracket type.
   if s:Match(lnum, '[[({})\]]')
     let counts = s:LineHasOpeningBrackets(lnum)
-    if counts[0] == '2' || (counts[1] == '2' && !s:Match(lnum, s:line_pre . '}'))
-          \ || (counts[2] == '2' && !s:Match(lnum, s:line_pre . ']'))
+    if counts[0] == '2' || (counts[1] == '2' && !s:Match(lnum, s:line_pre . '}')) ||
+          \ (counts[2] == '2' && !s:Match(lnum, s:line_pre . ']'))
       call cursor(lnum, 1)
       " Search for the opening tag
       let parlnum = searchpair('(\|{\|\[', '', ')\|}\|\]', 'nbW', s:skip_expr)

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -45,7 +45,7 @@ let s:line_pre = '^\s*\%(\/\*.*\*\/\s*\)*'
 let s:js_keywords = s:line_pre . '\%(break\|catch\|const\|continue\|debugger\|delete\|do\|else\|finally\|for\|function\|if\|in\|instanceof\|let\|new\|return\|switch\|this\|throw\|try\|typeof\|var\|void\|while\|with\)\>\C'
 let s:expr_case = s:line_pre . '\%(case\s\+[^\:]*\|default\)\s*:\s*\C'
 " Regex of syntax group names that are or delimit string or are comments.
-let s:syng_strcom = '\%(string\|comment\|template\)\c'
+let s:syng_strcom = '\%(string\|regex\|comment\|template\)\c'
 
 " Regex of syntax group names that are strings.
 let s:syng_string = 'regex\c'
@@ -120,10 +120,10 @@ function s:PrevNonBlankNonString(lnum)
   let lnum = prevnonblank(a:lnum)
   while lnum > 0
     let line = getline(lnum)
-    let com = match(line, '\*/') + 1
+    let com = match(line, '\*\/') + 1
     if s:IsInMultilineComment(lnum, com)
       call cursor(lnum, com)
-      let parlnum = search('/\*', 'nbW')
+      let parlnum = search('\/\*', 'nbW')
       if parlnum > 0
         let lnum = parlnum
       end
@@ -319,10 +319,10 @@ function GetJavascriptIndent()
   let line = getline(v:lnum)
   " previous nonblank line number
   let prevline = prevnonblank(v:lnum - 1)
-  
+
   " to not change multiline string values 
   if line !~ '^[''"`]' && synIDattr(synID(v:lnum, 1, 1), 'name') =~? 'string\|template'
-    return indent(v:lnum)
+    return -1
   endif
 
   " If we are in a multi-line comment, cindent does the right thing.

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -222,27 +222,6 @@ function s:InMultiVarStatement(lnum, cont, prev)
   return 0
 endfunction
 
-" Find line above with beginning of the var statement or returns 0 if it's not"{{{2
-" this statement
-" function s:GetVarIndent(lnum)
-"   let lvar = s:InMultiVarStatement(a:lnum, 0,0)
-"   let prev_lnum = s:PrevNonBlankNonString(a:lnum - 1)
-
-"   if lvar
-"     let line = s:RemoveTrailingComments(getline(prev_lnum))
-
-"     " if the previous line doesn't end in a comma, return to regular indent
-"     if (line !~ s:comma_last)
-"       return indent(prev_lnum) - s:sw()
-"     else
-"       return indent(lvar) + s:sw()
-"     endif
-"   endif
-
-"   return -1
-" endfunction"}}}
-
-
 " Check if line 'lnum' has more opening brackets than closing ones.
 function s:LineHasOpeningBrackets(lnum)
   let open_0 = 0


### PR DESCRIPTION
this makes almost no difference to the indenter's effects. I found that our most time consuming indent operation is from the 'skip_expr' which looks at syntax items, removing 'regex' from it seems to help a bit