### PR TITLE
Improve jsClassMethodDefinition matches

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -221,7 +221,7 @@ syntax match   jsArrowFuncArgs  /([^()]*)\s*\(=>\)\@=/ skipempty skipwhite conta
 
 syntax keyword jsClassKeywords extends class contained
 syntax match   jsClassNoise /\./ contained
-syntax keyword jsClassMethodDefinitions get set static contained nextgroup=jsFuncName skipwhite skipempty
+syntax match   jsClassMethodDefinitions /\%(get\|set\|static\)\%( \k\+\)\@=/ contained nextgroup=jsFuncName skipwhite skipempty
 syntax match   jsClassDefinition /\<class\>\%( [a-zA-Z_$][0-9a-zA-Z_$ \n.]*\)*/  contains=jsClassKeywords,jsClassNoise nextgroup=jsClassBlock skipwhite skipempty
 
 " Define the default highlighting.


### PR DESCRIPTION
Currently in a class definition, you can actually have a method called
`get`.  However with our match of `get` `set` and `static` as keywords,
we broke the ability to properly support those method names.  This
should fix those cases.