### PR TITLE
Improvements to Destructuring - Needs More Testing

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -369,7 +369,8 @@ function GetJavascriptIndent()
 
   " If line starts with an operator...
   if (line =~ s:operator_first)
-    if (s:Match(lnum, s:operator_first) || s:Match(lnum, s:line_pre . '[])}]'))
+    if (s:Match(lnum, s:operator_first) || (s:Match(lnum, s:line_pre . '[])}]') &&
+          \ !(s:Match(v:lnum,s:line_pre . '\.') && s:Match(lnum, ')' . s:line_term))))
       " and so does previous line, don't indent
       return indent(lnum)
     end

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -312,6 +312,7 @@ function GetJavascriptIndent()
   " 3.1. Setup {{{1
   " ----------
   " Set up variables for restoring position in file.  Could use v:lnum here.
+  " Avoid use of line('.')/col('.') type functions as the curpos can change
   let vcol = col('.')
 
   " 3.2. Work on the current line {{{1
@@ -334,7 +335,7 @@ function GetJavascriptIndent()
   if line !~ '^\%(\/\*\|\s*\/\/\)' && s:IsInComment(v:lnum, 1)
     return cindent(v:lnum)
   endif
-  
+
   " single opening bracket will assume you want a c style of indenting
   if s:Match(v:lnum, s:line_pre . '{' . s:line_term) && !s:Match(lnum,s:block_regex) &&
         \ !s:Match(lnum,s:comma_last)
@@ -429,16 +430,16 @@ function GetJavascriptIndent()
     return 0
   endif
 
-" foo('foo',
-"   bar('bar', function() {
-"     hi();
-"   })
-" );
+  " foo('foo',
+  "   bar('bar', function() {
+  "     hi();
+  "   })
+  " );
 
-" function (a, b, c, d,
-"     e, f, g) {
-"       console.log('inner');
-" }
+  " function (a, b, c, d,
+  "     e, f, g) {
+  "       console.log('inner');
+  " }
   " If the previous line ended with a block opening, add a level of indent.
   if s:Match(lnum, s:block_regex)
     return s:InMultiVarStatement(lnum, 0, 0) || s:LineHasOpeningBrackets(lnum) !~ '2' ?
@@ -450,15 +451,16 @@ function GetJavascriptIndent()
   let ind = indent(lnum)
   " If the previous line contained an opening bracket, and we are still in it,
   " add indent depending on the bracket type.
-  if s:Match(lnum, '\%([[({]\)\|\%([^\t \])}][})\]]\)')
+  if s:Match(lnum, '[[({})\]]')
     let counts = s:LineHasOpeningBrackets(lnum)
     if counts =~ '2'
-      call cursor(lnum,matchend(s:RemoveTrailingComments(line), '.\+\zs[])}]'))
+      call cursor(lnum,matchend(s:RemoveTrailingComments(line), '.*\zs[])}]'))
       while s:lookForParens('(\|{\|\[', ')\|}\|\]', 'bW', 0) == lnum
         call cursor(lnum, matchend(s:RemoveTrailingComments(strpart(line,0,col('.'))), '.*\zs[])}]'))
       endwhile
-      if line('.') < lnum && !s:InMultiVarStatement(line('.'),0,0)
-        return indent(s:GetMSL(line('.'), 0))
+      let cur = line('.')
+      if cur < lnum && !s:InMultiVarStatement(cur,0,0)
+        return indent(s:GetMSL(cur, 0))
       end
     elseif counts =~ '1' || s:Onescope(lnum)
       return ind + s:sw()
@@ -501,64 +503,64 @@ let &cpo = s:cpo_save
 unlet s:cpo_save
 " gq{{{2
 function! Fixedgq(lnum, count)
-    let l:tw = &tw ? &tw : 80;
+  let l:tw = &tw ? &tw : 80;
 
-    let l:count = a:count
-    let l:first_char = indent(a:lnum) + 1
+  let l:count = a:count
+  let l:first_char = indent(a:lnum) + 1
 
-    if mode() == 'i' " gq was not pressed, but tw was set
-        return 1
-    endif
+  if mode() == 'i' " gq was not pressed, but tw was set
+    return 1
+  endif
 
-    " This gq is only meant to do code with strings, not comments
-    if s:IsInComment(a:lnum, l:first_char)
-        return 1
-    endif
+  " This gq is only meant to do code with strings, not comments
+  if s:IsInComment(a:lnum, l:first_char)
+    return 1
+  endif
 
-    if len(getline(a:lnum)) < l:tw && l:count == 1 " No need for gq
-        return 1
-    endif
+  if len(getline(a:lnum)) < l:tw && l:count == 1 " No need for gq
+    return 1
+  endif
 
-    " Put all the lines on one line and do normal spliting after that
-    if l:count > 1
-        while l:count > 1
-            let l:count -= 1
-            normal J
-        endwhile
-    endif
+  " Put all the lines on one line and do normal spliting after that
+  if l:count > 1
+    while l:count > 1
+      let l:count -= 1
+      normal J
+    endwhile
+  endif
 
-    let l:winview = winsaveview()
+  let l:winview = winsaveview()
 
+  call cursor(a:lnum, l:tw + 1)
+  let orig_breakpoint = searchpairpos(' ', '', '\.', 'bcW', '', a:lnum)
+  call cursor(a:lnum, l:tw + 1)
+  let breakpoint = searchpairpos(' ', '', '\.', 'bcW', s:skip_expr, a:lnum)
+
+  " No need for special treatment, normal gq handles edgecases better
+  if breakpoint[1] == orig_breakpoint[1]
+    call winrestview(l:winview)
+    return 1
+  endif
+
+  " Try breaking after string
+  if breakpoint[1] <= indent(a:lnum)
     call cursor(a:lnum, l:tw + 1)
-    let orig_breakpoint = searchpairpos(' ', '', '\.', 'bcW', '', a:lnum)
-    call cursor(a:lnum, l:tw + 1)
-    let breakpoint = searchpairpos(' ', '', '\.', 'bcW', s:skip_expr, a:lnum)
-
-    " No need for special treatment, normal gq handles edgecases better
-    if breakpoint[1] == orig_breakpoint[1]
-        call winrestview(l:winview)
-        return 1
-    endif
-
-    " Try breaking after string
-    if breakpoint[1] <= indent(a:lnum)
-        call cursor(a:lnum, l:tw + 1)
-        let breakpoint = searchpairpos('\.', '', ' ', 'cW', s:skip_expr, a:lnum)
-    endif
+    let breakpoint = searchpairpos('\.', '', ' ', 'cW', s:skip_expr, a:lnum)
+  endif
 
 
-    if breakpoint[1] != 0
-        call feedkeys("r\<CR>")
-    else
-        let l:count = l:count - 1
-    endif
+  if breakpoint[1] != 0
+    call feedkeys("r\<CR>")
+  else
+    let l:count = l:count - 1
+  endif
 
-    " run gq on new lines
-    if l:count == 1
-        call feedkeys("gqq")
-    endif
+  " run gq on new lines
+  if l:count == 1
+    call feedkeys("gqq")
+  endif
 
-    return 0
+  return 0
 endfunction
 "}}}
 " vim: foldmethod=marker:foldlevel=1

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -24,12 +24,12 @@ syntax sync fromstart
 " syntax case ignore
 syntax case match
 
-syntax match   jsNoise           /[:,\;\.]\{1}/
-syntax match   jsFuncCall         /\k\+\%(\s*(\)\@=/
-syntax match   jsParensError    /\%()\|}\|\]\)/
+syntax match   jsNoise          /[:,\;\.]\{1}/
+syntax match   jsFuncCall       /\k\+\%(\s*(\)\@=/
+syntax match   jsParensError    /[)}\]]/
 
 " Program Keywords
-syntax keyword jsStorageClass   const var let
+syntax keyword jsStorageClass   const var let skipwhite skipempty nextgroup=jsDestructuringBlock
 syntax keyword jsOperator       delete instanceof typeof void new in of
 syntax match   jsOperator       /[\!\|\&\+\-\<\>\=\%\/\*\~\^]\{1}/
 syntax match   jsSpreadOperator /\.\.\./ skipwhite skipempty nextgroup=@jsExpression
@@ -45,7 +45,7 @@ syntax region  jsModuleGroup     contained matchgroup=jsBraces start=/{/ end=/}/
 syntax match   jsModuleAsterisk  contained /*/
 syntax keyword jsModuleDefault   contained default skipwhite skipempty nextgroup=@jsExpression
 syntax region jsImportContainer  start=/\<import\> / end="\%(;\|$\)" contains=jsModuleKeywords,jsModuleOperators,jsComment,jsString,jsTemplateString,jsNoise,jsModuleGroup,jsModuleAsterisk
-syntax match  jsExportContainer   /\<export\> / contains=jsModuleKeywords skipwhite skipempty nextgroup=jsExportBlock,jsModuleDefault
+syntax match  jsExportContainer  /\<export\> / contains=jsModuleKeywords skipwhite skipempty nextgroup=jsExportBlock,jsModuleDefault
 syntax region jsExportBlock      contained matchgroup=jsBraces start=/{/ end=/}/ contains=jsModuleOperators,jsNoise
 
 " Strings, Templates, Numbers
@@ -129,24 +129,25 @@ syntax keyword jsDomNodeConsts  ELEMENT_NODE ATTRIBUTE_NODE TEXT_NODE CDATA_SECT
 syntax keyword jsHtmlEvents     onblur onclick oncontextmenu ondblclick onfocus onkeydown onkeypress onkeyup onmousedown onmousemove onmouseout onmouseover onmouseup onresize
 
 "" Code blocks
-syntax region  jsBracket                 matchgroup=jsBrackets          start="\[" end="\]" contains=@jsExpression extend fold
-syntax region  jsParen                   matchgroup=jsParens            start=/(/  end=/)/  contains=@jsAll extend fold
-syntax region  jsParenIfElse   contained matchgroup=jsParens            start=/(/  end=/)/  contains=@jsAll skipwhite skipempty nextgroup=jsBlock extend fold
-syntax region  jsParenRepeat   contained matchgroup=jsParens            start=/(/  end=/)/  contains=@jsAll skipwhite skipempty nextgroup=jsBlock extend fold
-syntax region  jsParenSwitch   contained matchgroup=jsParens            start=/(/  end=/)/  contains=@jsAll skipwhite skipempty nextgroup=jsSwitchBlock extend fold
-syntax region  jsParenCatch    contained matchgroup=jsParens            start=/(/  end=/)/  skipwhite skipempty nextgroup=jsTryCatchBlock extend fold
-syntax region  jsClassBlock    contained matchgroup=jsClassBraces       start=/{/  end=/}/  contains=jsClassFuncName,jsClassMethodDefinitions,jsOperator,jsArrowFunction,jsArrowFuncArgs,jsComment,jsGenerator,jsDecorator,jsClassProperty,jsClassPropertyComputed,jsClassStringKey,jsNoise extend fold
-syntax region  jsFuncBlock     contained matchgroup=jsFuncBraces        start=/{/  end=/}/  contains=@jsAll extend fold
-syntax region  jsBlock         contained matchgroup=jsBraces            start=/{/  end=/}/  contains=@jsAll extend fold
-syntax region  jsTryCatchBlock contained matchgroup=jsBraces            start=/{/  end=/}/  contains=@jsAll skipwhite skipempty nextgroup=jsCatch,jsFinally extend fold
-syntax region  jsSwitchBlock   contained matchgroup=jsBraces            start=/{/  end=/}/  contains=@jsAll,jsLabel extend fold
-syntax region  jsObject                  matchgroup=jsObjectBraces      start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectGetSet,jsGenerator,jsComment,jsSpreadOperator,jsObjectStringKey extend fold
-syntax region  jsTernaryIf               matchgroup=jsTernaryIfOperator start=/?/  end=/\%(:\|[\}]\@=\)/  contains=@jsExpression
+syntax region  jsBracket                      matchgroup=jsBrackets            start="\[" end="\]" contains=@jsExpression extend fold
+syntax region  jsParen                        matchgroup=jsParens              start=/(/  end=/)/  contains=@jsAll extend fold
+syntax region  jsParenIfElse        contained matchgroup=jsParens              start=/(/  end=/)/  contains=@jsAll skipwhite skipempty nextgroup=jsBlock extend fold
+syntax region  jsParenRepeat        contained matchgroup=jsParens              start=/(/  end=/)/  contains=@jsAll skipwhite skipempty nextgroup=jsBlock extend fold
+syntax region  jsParenSwitch        contained matchgroup=jsParens              start=/(/  end=/)/  contains=@jsAll skipwhite skipempty nextgroup=jsSwitchBlock extend fold
+syntax region  jsParenCatch         contained matchgroup=jsParens              start=/(/  end=/)/  skipwhite skipempty nextgroup=jsTryCatchBlock extend fold
+syntax region  jsFuncArgs           contained matchgroup=jsFuncParens          start='('  end=')'  contains=jsFuncArgCommas,jsFuncArgRest,jsComment,jsFuncArgExpression,jsDestructuringBlock skipwhite skipempty nextgroup=jsFuncBlock extend fold
+syntax region  jsClassBlock         contained matchgroup=jsClassBraces         start=/{/  end=/}/  contains=jsClassFuncName,jsClassMethodDefinitions,jsOperator,jsArrowFunction,jsArrowFuncArgs,jsComment,jsGenerator,jsDecorator,jsClassProperty,jsClassPropertyComputed,jsClassStringKey,jsNoise extend fold
+syntax region  jsFuncBlock          contained matchgroup=jsFuncBraces          start=/{/  end=/}/  contains=@jsAll extend fold
+syntax region  jsBlock              contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll extend fold
+syntax region  jsTryCatchBlock      contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll skipwhite skipempty nextgroup=jsCatch,jsFinally extend fold
+syntax region  jsSwitchBlock        contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll,jsLabel extend fold
+syntax region  jsDestructuringBlock contained matchgroup=jsDestructuringBraces start=/{/  end=/}/  contains=jsDestructuringProperty,jsDestructuringAssignment,jsDestructuringNoise,jsDestructuringPropertyComputed extend fold
+syntax region  jsObject                       matchgroup=jsObjectBraces        start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectGetSet,jsGenerator,jsComment,jsSpreadOperator,jsObjectStringKey extend fold
+syntax region  jsTernaryIf                    matchgroup=jsTernaryIfOperator   start=/?/  end=/\%(:\|[\}]\@=\)/  contains=@jsExpression
 
 syntax match   jsGenerator            contained /\*/ skipwhite skipempty nextgroup=jsFuncName,jsFuncArgs
 syntax match   jsFuncName             contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>/ skipwhite skipempty nextgroup=jsFuncArgs
-syntax match   jsFuncArgDestructuring contained /\({\|}\|=\|:\|\[\|\]\)/ extend
-syntax region  jsFuncArgs             contained matchgroup=jsFuncParens start='(' end=')' contains=jsFuncArgCommas,jsFuncArgRest,jsComment,jsString,jsNumber,jsFuncArgDestructuring,jsArrowFunction,jsParen,jsArrowFuncArgs skipwhite skipempty nextgroup=jsFuncBlock extend
+syntax region  jsFuncArgExpression    contained matchgroup=jsFuncArgOperator start=/=/ end=/[,)]\@=/ contains=@jsExpression extend
 syntax match   jsFuncArgCommas        contained ','
 syntax match   jsFuncArgRest          contained /\%(\.\.\.[a-zA-Z_$][0-9a-zA-Z_$]*\))/ contains=jsFuncArgRestDots
 syntax match   jsFuncArgRestDots      contained /\.\.\./
@@ -172,6 +173,13 @@ syntax region  jsClassPropertyComputed  contained matchgroup=jsBrackets start=/\
 syntax match   jsClassFuncName          contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\%(\s*(\)\@=/ skipwhite skipempty nextgroup=jsFuncArgs
 syntax region  jsClassStringKey         contained start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@Spell extend skipwhite skipempty nextgroup=jsFuncArgs
 syntax region  jsClassStringKey         contained start=+'+  skip=+\\\('\|$\)+  end=+'\|$+  contains=jsSpecial,@Spell extend skipwhite skipempty nextgroup=jsFuncArgs
+
+" Destructuring
+syntax match   jsDestructuringProperty          contained /\<[0-9a-zA-Z_$]*\>\(\s*=\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
+syntax match   jsDestructuringAssignment        contained /\<[0-9a-zA-Z_$]*\>\(\s*:\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
+syntax region  jsDestructuringValue             contained start=/=/ start=/:/ end=/\%(,\|}\)\@=/ contains=@jsExpression extend
+syntax match   jsDestructuringNoise             contained /[,]/
+syntax region  jsDestructuringPropertyComputed  contained matchgroup=jsBrackets start=/\[/ end=/]/ contains=@jsExpresslon skipwhite skipempty nextgroup=jsDestructuringValue,jsDestructuringNoise extend fold
 
 " Comments
 syntax keyword jsCommentTodo    contained TODO FIXME XXX TBD
@@ -305,10 +313,15 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsDecorator            Special
   HiLink jsDecoratorFunction    Special
   HiLink jsFuncArgRestDots      Noise
-  HiLink jsFuncArgDestructuring Noise
+  HiLink jsFuncArgOperator      jsFuncArgs
   HiLink jsModuleAsterisk       Noise
   HiLink jsClassProperty        jsObjectKey
   HiLink jsSpreadOperator       Operator
+
+  HiLink jsDestructuringBraces     Noise
+  HiLink jsDestructuringProperty   jsObjectKey
+  HiLink jsDestructuringAssignment jsObjectKey
+  HiLink jsDestructuringNoise      Noise
 
   HiLink jsDomErrNo             Constant
   HiLink jsDomNodeConsts        Constant

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -142,8 +142,7 @@ syntax region  jsBlock              contained matchgroup=jsBraces              s
 syntax region  jsTryCatchBlock      contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll skipwhite skipempty nextgroup=jsCatch,jsFinally extend fold
 syntax region  jsSwitchBlock        contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll,jsLabel extend fold
 syntax region  jsDestructuringBlock contained matchgroup=jsDestructuringBraces start=/{/  end=/}/  contains=jsDestructuringProperty,jsDestructuringAssignment,jsDestructuringNoise,jsDestructuringPropertyComputed extend fold
-syntax region  jsDestructuringArray contained matchgroup=jsDestructuringBraces start=/\[/ end=/\]/ contains=jsDestructuringPropertyValue,jsNoise extend fold
-syntax region  jsObject                       matchgroup=jsObjectBraces        start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectGetSet,jsGenerator,jsComment,jsSpreadOperator,jsObjectStringKey extend fold
+syntax region  jsDestructuringArray contained matchgroup=jsDestructuringBraces start=/\[/ end=/\]/ contains=jsDestructuringPropertyValue,jsNoise,jsDestructuringProperty extend fold
 syntax region  jsObject                       matchgroup=jsObjectBraces        start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectGetSet,jsGenerator,jsComment,jsSpreadOperator,jsObjectStringKey extend fold
 syntax region  jsTernaryIf                    matchgroup=jsTernaryIfOperator   start=/?/  end=/\%(:\|[\}]\@=\)/  contains=@jsExpression
 
@@ -177,11 +176,11 @@ syntax region  jsClassStringKey         contained start=+"+  skip=+\\\("\|$\)+  
 syntax region  jsClassStringKey         contained start=+'+  skip=+\\\('\|$\)+  end=+'\|$+  contains=jsSpecial,@Spell extend skipwhite skipempty nextgroup=jsFuncArgs
 
 " Destructuring
-syntax match   jsDestructuringProperty          contained /\<[0-9a-zA-Z_$]*\>\(\s*=\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
-syntax match   jsDestructuringAssignment        contained /\<[0-9a-zA-Z_$]*\>\(\s*:\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
 syntax match   jsDestructuringPropertyValue     contained /\<[0-9a-zA-Z_$]*\>/
-syntax region  jsDestructuringValue             contained start=/=/ end=/\%(,\|}\)\@=/ contains=@jsExpression extend
-syntax region  jsDestructuringValue             contained start=/:/ end=/\%(,\|}\)\@=/ contains=jsDestructuringPropertyValue,jsDestructuringBlock,jsNoise,jsDestructuringNoise extend
+syntax match   jsDestructuringProperty          contained /\<[0-9a-zA-Z_$]*\>\(\s*=\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
+syntax match   jsDestructuringAssignment        contained /\<[0-9a-zA-Z_$]*\>\(\s*:\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValueAssignment
+syntax region  jsDestructuringValue             contained start=/=/ end=/[,}\]]\@=/ contains=@jsExpression extend
+syntax region  jsDestructuringValueAssignment   contained start=/:/ end=/[,}]\@=/ contains=jsDestructuringPropertyValue,jsDestructuringBlock,jsNoise,jsDestructuringNoise extend
 syntax match   jsDestructuringNoise             contained /[,\[\]]/
 syntax region  jsDestructuringPropertyComputed  contained matchgroup=jsBrackets start=/\[/ end=/]/ contains=@jsExpresslon skipwhite skipempty nextgroup=jsDestructuringValue,jsDestructuringNoise extend fold
 

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -177,8 +177,10 @@ syntax region  jsClassStringKey         contained start=+'+  skip=+\\\('\|$\)+  
 " Destructuring
 syntax match   jsDestructuringProperty          contained /\<[0-9a-zA-Z_$]*\>\(\s*=\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
 syntax match   jsDestructuringAssignment        contained /\<[0-9a-zA-Z_$]*\>\(\s*:\)\@=/ skipwhite skipempty nextgroup=jsDestructuringValue
-syntax region  jsDestructuringValue             contained start=/=/ start=/:/ end=/\%(,\|}\)\@=/ contains=@jsExpression extend
-syntax match   jsDestructuringNoise             contained /[,]/
+syntax match   jsDestructuringPropertyValue     contained /\<[0-9a-zA-Z_$]*\>/
+syntax region  jsDestructuringValue             contained start=/=/ end=/\%(,\|}\)\@=/ contains=@jsExpression extend
+syntax region  jsDestructuringValue             contained start=/:/ end=/\%(,\|}\)\@=/ contains=jsDestructuringPropertyValue,jsDestructuringBlock,jsNoise,jsDestructuringNoise extend
+syntax match   jsDestructuringNoise             contained /[,\[\]]/
 syntax region  jsDestructuringPropertyComputed  contained matchgroup=jsBrackets start=/\[/ end=/]/ contains=@jsExpresslon skipwhite skipempty nextgroup=jsDestructuringValue,jsDestructuringNoise extend fold
 
 " Comments
@@ -319,7 +321,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsSpreadOperator       Operator
 
   HiLink jsDestructuringBraces     Noise
-  HiLink jsDestructuringProperty   jsObjectKey
+  HiLink jsDestructuringProperty   jsFuncArgs
   HiLink jsDestructuringAssignment jsObjectKey
   HiLink jsDestructuringNoise      Noise
 

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -29,7 +29,7 @@ syntax match   jsFuncCall       /\k\+\%(\s*(\)\@=/
 syntax match   jsParensError    /[)}\]]/
 
 " Program Keywords
-syntax keyword jsStorageClass   const var let skipwhite skipempty nextgroup=jsDestructuringBlock
+syntax keyword jsStorageClass   const var let skipwhite skipempty nextgroup=jsDestructuringBlock,jsDestructuringArray
 syntax keyword jsOperator       delete instanceof typeof void new in of
 syntax match   jsOperator       /[\!\|\&\+\-\<\>\=\%\/\*\~\^]\{1}/
 syntax match   jsSpreadOperator /\.\.\./ skipwhite skipempty nextgroup=@jsExpression
@@ -142,6 +142,8 @@ syntax region  jsBlock              contained matchgroup=jsBraces              s
 syntax region  jsTryCatchBlock      contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll skipwhite skipempty nextgroup=jsCatch,jsFinally extend fold
 syntax region  jsSwitchBlock        contained matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll,jsLabel extend fold
 syntax region  jsDestructuringBlock contained matchgroup=jsDestructuringBraces start=/{/  end=/}/  contains=jsDestructuringProperty,jsDestructuringAssignment,jsDestructuringNoise,jsDestructuringPropertyComputed extend fold
+syntax region  jsDestructuringArray contained matchgroup=jsDestructuringBraces start=/\[/ end=/\]/ contains=jsDestructuringPropertyValue,jsNoise extend fold
+syntax region  jsObject                       matchgroup=jsObjectBraces        start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectGetSet,jsGenerator,jsComment,jsSpreadOperator,jsObjectStringKey extend fold
 syntax region  jsObject                       matchgroup=jsObjectBraces        start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectGetSet,jsGenerator,jsComment,jsSpreadOperator,jsObjectStringKey extend fold
 syntax region  jsTernaryIf                    matchgroup=jsTernaryIfOperator   start=/?/  end=/\%(:\|[\}]\@=\)/  contains=@jsExpression
 


### PR DESCRIPTION
This PR should add far more complete support for destructuring, both in
var/let/const statements and also within function argument definitions.

There may be some cases I have not tested and are broken, therefore more
testing is for sure needed.

I've been using this file for reference:

```js
var [a, b] = [1, 2];
var [a, b, ...rest] = [1, 2, 3, 4, 5]
var {a, b} = {a:1, b:2}
var {a, b, ...rest} = {a:1, b:2, c:3, d:4};
var x = [1, 2, 3, 4, 5];
var x = [1, 2, 3, 4, 5];
var [y, z] = x;
var [one, two, three] = foo;
var [a, b] = [1, 2];
var [a=5, b=7] = [1];
var a = 1;
var b = 3;
const [a, b] = [b, a];
var a, b;
var [a, b] = f();
var [a, , b] = f();
var [, protocol, fullhost, fullpath] = parsedURL;
var o = {p: 42, q: true};
var {p, q} = o;
var a, b;
let {a, b} = {a:1, b:2};
var o = {p: 42, q: true};
var {p: foo, q: bar} = o;
var {a=10, b=5} = {a: 3};
function drawES6Chart({size = 'big', cords = { x: 0, y: 0 }, radius = 25} = {}){}
const { Loader, main } = require('toolkit/loader');
var { title: englishTitle, translations: [{ title: localeTitle }] } = metadata;
for (var {name: n, family: { father: f } } of people) {}
function userId({id}) {}
function whois({displayName: displayName, fullName: {firstName: name}}){}
let { [key]: foo } = { z: "bar" };
```

And for reference, what it looks like using my custom colorscheme:

![destructuring example](https://dl.dropboxusercontent.com/s/yrjs6rncntlzm47/destructuring.js_2016-06-13_23-19-51.png?dl=0)