### PR TITLE
accurate switch indenting

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -344,7 +344,11 @@ function GetJavascriptIndent()
 
   " cindent each line which has a switch label
   if (line =~ s:expr_case)
-    return cindent(v:lnum)
+    let s:cpo_switch = &cpo
+    set cpo+=%
+    let ind = cindent(v:lnum)
+    let &cpo = s:cpo_switch
+    return ind
   endif
 
   " If we got a closing bracket on an empty line, find its match and indent


### PR DESCRIPTION
since cindent considers single quotes as delimiting a single char string, cindent will break in situations like : https://github.com/sanctuary-js/sanctuary-def/blob/master/index.js#L222

http://stackoverflow.com/questions/3683602/single-quotes-vs-double-quotes-in-c