### PR TITLE
Linking jsClassDefinition to jsFuncName

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -300,6 +300,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsSwitchColon          Noise
   HiLink jsClassMethodType      Type
   HiLink jsObjectMethodType     Type
+  HiLink jsClassDefinition      jsFuncName
 
   HiLink jsDestructuringBraces     Noise
   HiLink jsDestructuringProperty   jsFuncArgs


### PR DESCRIPTION
They really should be linked, because jsClassDefinition is really just a function