### PR TITLE
typo

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -42,7 +42,7 @@ syntax keyword jsModuleOperators contained from
 syntax keyword jsModuleOperators contained as
 syntax region  jsModuleGroup     contained matchgroup=jsBraces start=/{/ end=/}/ contains=jsModuleOperators,jsNoise,jsComment
 syntax match   jsModuleAsterisk  contained /*/
-syntax keyword jsModuleDefault   contained default skipwhite kipempty nextgroup=@jsExpression
+syntax keyword jsModuleDefault   contained default skipwhite skipempty nextgroup=@jsExpression
 syntax region  jsImportContainer start=/\<import\> / end="\%(;\|$\)" contains=jsModuleKeywords,jsModuleOperators,jsComment,jsString,jsTemplateString,jsNoise,jsModuleGroup,jsModuleAsterisk
 syntax region  jsExportContainer start=/\<export\> / end="\%(;\|$\)" contains=jsModuleKeywords,jsModuleOperators,jsStorageClass,jsModuleDefault,@jsExpression
 syntax region  jsExportBlock     contained matchgroup=jsBraces start=/{/ end=/}/ contains=jsModuleOperators,jsNoise,jsComment


### PR DESCRIPTION
Additionnal thoughts: 
- thought about having NodeJS keywords?
- Add `@Comment` group to `syntax region  jsComment        start=/\/\// end=/$/ contains=jsCommentTodo,@Spell extend keepend`? That way people can add their own comment-highlighting whitout hacking through the whole syntax.