### PR TITLE
Update ftplugin

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -3,4 +3,6 @@
 " Maintainer:   vim-javascript community
 " URL:          https://github.com/pangloss/vim-javascript
 
-setlocal suffixesadd+=.js
+setlocal iskeyword+=$ suffixesadd+=.js
+
+let b:undo_ftplugin .= ' | setlocal iskeyword< suffixesadd<'

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -4,7 +4,3 @@
 " URL:          https://github.com/pangloss/vim-javascript
 
 setlocal suffixesadd+=.js
-
-if v:version == 703 && exists('&regexpengine') || v:version == 704 && !has('patch2')
-  set regexpengine=1
-endif


### PR DESCRIPTION
Removed `'regexpengine'` workaround. Setting `'regexpengine'` from filetype plugin without reenabling syntax doesn't fix problems described in #88 and #93.

I have tested some old versions of Vim. Seems like those problems are reproducible only in versions 7.4 and 7.4.1. Those few unfortunates who encounter it today will be able to find fix in project issues.

Filetype plugin moved to after directory so now it's possible to use `b:undo_ftplugin` variable.