### PR TITLE
settings

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -12,11 +12,11 @@ let b:did_indent = 1
 
 " Now, set up our indentation expression and keys that trigger it.
 setlocal indentexpr=GetJavascriptIndent()
-setlocal nolisp
+setlocal nolisp noautoindent nosmartindent
 setlocal indentkeys=0{,0},0),0],:,!^F,o,O,e
 setlocal cinoptions+=j1,J1
 
-let b:undo_indent = 'setlocal indentexpr< indentkeys< cinoptions<'
+let b:undo_indent = 'setlocal indentexpr< smartindent< autoindent< indentkeys< cinoptions<'
 
 " Only define the function once.
 if exists('*GetJavascriptIndent')


### PR DESCRIPTION
these don't seem to be very relevant when using indentexprs, and may override the indentation script,

opinions on this are welcomed, and honestly I don't know exactly what effect these have. the clojure indent file and a few others included with vim has these options set to off