### PR TITLE
Fix export default style indents

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -83,7 +83,7 @@ endfunction
 " https://github.com/sweet-js/sweet.js/wiki/design#give-lookbehind-to-the-reader
 function s:IsBlock()
   return getline(line('.'))[col('.')-1] == '{' && !search(
-        \ '\C\%(\<return\s*\|\%([-=~!<*+,.?^%|&\[(]\|=\@<!>\|\*\@<!\/\|\<\%(var\|const\|let\|import\|export\|yield\|delete\|void\|t\%(ypeof\|hrow\)\|new\|\<in\%(stanceof\)\=\)\)\_s*\)\%#','bnW') &&
+        \ '\C\%(\<return\s*\|\%([-=~!<*+,.?^%|&\[(]\|=\@<!>\|\*\@<!\/\|\<\%(var\|const\|let\|import\|export\|default\|yield\|delete\|void\|t\%(ypeof\|hrow\)\|new\|\<in\%(stanceof\)\=\)\)\_s*\)\%#','bnW') &&
         \ (!search(':\_s*\%#','bW') || (!s:GetPair('[({[]','[])}]','bW',200) || s:IsBlock()))
 endfunction
 


### PR DESCRIPTION
/cc @bounceme 

I found an issue when using `export default` statements, indentation would not work properly.

I saw how you fixed an earlier import statement and modeled it after that.

Before this PR:
```js
export default {
    'key': 'val',
        'secondKey': 'val'
}
```

After this PR:
```js
export default {
    'key': 'val',
    'secondKey': 'val'
}
```