### PR TITLE
Fix jsFlowTypeCustom regex to allow dots

### DIFF
--- a/extras/flow.vim
+++ b/extras/flow.vim
@@ -6,7 +6,7 @@ syntax region  jsFlowParens         contained matchgroup=jsFlowNoise start=/(/  
 syntax match   jsFlowNoise          contained /[:;,<>]/
 syntax keyword jsFlowType           contained boolean number string null void any mixed JSON array function object array bool class
 syntax keyword jsFlowTypeof         contained typeof skipempty skipempty nextgroup=jsFlowTypeCustom,jsFlowType
-syntax match   jsFlowTypeCustom     contained /\k*/ skipwhite skipempty nextgroup=jsFlowGroup
+syntax match   jsFlowTypeCustom     contained /[0-9a-zA-Z_.]*/ skipwhite skipempty nextgroup=jsFlowGroup
 syntax region  jsFlowGroup          contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster
 syntax region  jsFlowArrowArguments contained matchgroup=jsFlowNoise start=/(/  end=/)\%(\s*=>\)\@=/ oneline skipwhite skipempty nextgroup=jsFlowArrow contains=@jsFlowCluster
 syntax match   jsFlowArrow          contained /=>/ skipwhite skipempty nextgroup=jsFlowType,jsFlowTypeCustom,jsFlowParens


### PR DESCRIPTION
It’s possible to use dots in Flow types, but the syntax did not allow it, and it broke how the rest of the content was highlighted.

I’m not really sure why `\k` was used here (I don’t have a lot of experience with Vim’s `syntax match`), but I’ll gladly update the regex with something more appropriate, as long as it accepts dots 😄 

#### Before

<img width="332" alt="" src="https://cloud.githubusercontent.com/assets/11348/18811848/6581c98e-828d-11e6-9e3c-c5b491cad07e.png">

#### After

<img width="325" src="https://cloud.githubusercontent.com/assets/11348/18811850/6c9c80d8-828d-11e6-8088-704af2f9cc93.png">