### PR TITLE
Implement jsFuncAssignment

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -29,7 +29,7 @@ syntax match   jsFuncCall       /\k\+\%(\s*(\)\@=/
 syntax match   jsParensError    /[)}\]]/
 
 " Program Keywords
-syntax keyword jsStorageClass   const var let skipwhite skipempty nextgroup=jsDestructuringBlock,jsDestructuringArray,jsVariableDef
+syntax keyword jsStorageClass   const var let skipwhite skipempty nextgroup=jsDestructuringBlock,jsDestructuringArray,jsVariableDef,jsFuncAssignment
 syntax match   jsVariableDef    contained /\k\+/ nextgroup=jsFlowDefinition
 syntax keyword jsOperator       delete instanceof typeof void new in of
 syntax match   jsOperator       /[\!\|\&\+\-\<\>\=\%\/\*\~\^]\{1}/
@@ -166,6 +166,11 @@ syntax match   jsFuncArgCommas        contained ','
 syntax keyword jsArguments            contained arguments
 syntax keyword jsForAwait             contained await skipwhite skipempty nextgroup=jsParenRepeat
 
+syntax match jsFuncAssignment        contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\s*=\s*([^()]*)\s*\(=>\)\@=/ skipwhite contains=jsFuncAssignmentPattern nextgroup=jsFuncAssignmentPattern
+syntax match jsFuncAssignment        contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\s*=\s*\k\+\s*\%(=>\)\@=/ skipwhite contains=jsFuncAssignmentPattern nextgroup=jsFuncAssignmentPattern
+syntax match jsFuncAssignmentPattern contained /=\s*([^()]*)\s*\(=>\)\@=/ skipwhite skipempty contains=jsArrowFuncArgs nextgroup=jsArrowFunction
+syntax match jsFuncAssignmentPattern contained /=\s*\k\+\s*\%(=>\)\@=/ skipwhite skipempty contains=jsArrowFuncArgs nextgroup=jsArrowFunction
+
 " Matches a single keyword argument with no parens
 syntax match   jsArrowFuncArgs  /\k\+\s*\%(=>\)\@=/ skipwhite contains=jsFuncArgs skipwhite skipempty nextgroup=jsArrowFunction extend
 " Matches a series of arguments surrounded in parens
@@ -282,6 +287,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsGenerator            jsFunction
   HiLink jsArrowFuncArgs        jsFuncArgs
   HiLink jsFuncName             Function
+  HiLink jsFuncAssignment       Function
   HiLink jsClassFuncName        jsFuncName
   HiLink jsObjectFuncName       Function
   HiLink jsArguments            Special


### PR DESCRIPTION
This resolves #694, albeit in a potentially suboptimal / incorrect way (I am new to Vim syntax programming).

If you decide to merge this pull request, we may also want to remove the `HiLink jsFuncAssignment       Function` line as a default. 

I'm happy to accommodate any requirements for merging or alternatively keeping this in a private fork if this isn't functionality you think belongs in the main branch.

Thanks!