### PR TITLE
trim from start of comment sequence

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -84,10 +84,10 @@ endfunction
 
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([match(pline,'.*\zs\/\@<!\/[/*]'),0])
+  let l:max = max([match(pline,'.*[^/]\zs\/[/*]'),0])
   while l:max && synIDattr(synID(a:ln, strlen(pline), 0), 'name') =~? 'comment\|doc'
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
-    let l:max = max([match(pline,'.*\zs\/\@<!\/[/*]'),0])
+    let l:max = max([match(pline,'.*[^/]\zs\/[/*]'),0])
   endwhile
   return pline
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -84,10 +84,10 @@ endfunction
 
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([match(pline,'.*\zs\/\@>[/*]'),0])
+  let l:max = max([match(pline,'.*[^/]\zs\/[/*]'),0])
   while l:max && synIDattr(synID(a:ln, strlen(pline), 0), 'name') =~? 'comment\|doc'
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
-    let l:max = max([match(pline,'.*\zs\/\@>[/*]'),0])
+    let l:max = max([match(pline,'.*[^/]\zs\/[/*]'),0])
   endwhile
   return pline
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -84,10 +84,10 @@ endfunction
 
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([match(pline,'.*\zs\/[/*]'),0])
+  let l:max = max([match(pline,'.*\zs\/[/*]*'),0])
   while l:max && synIDattr(synID(a:ln, strlen(pline), 0), 'name') =~? 'comment\|doc'
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
-    let l:max = max([match(pline,'.*\zs\/[/*]'),0])
+    let l:max = max([match(pline,'.*\zs\/[/*]*'),0])
   endwhile
   return pline
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -84,11 +84,12 @@ endfunction
 
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([match(pline,'.*\zs\/[/*]\+'),0])
+  let l:max = max([match(pline,'.*\zs\/\@>[/*]'),0])
   while l:max && synIDattr(synID(a:ln, strlen(pline), 0), 'name') =~? 'comment\|doc'
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
-    let l:max = max([match(pline,'.*\zs\/[/*]\+'),0])
+    let l:max = max([match(pline,'.*\zs\/\@>[/*]'),0])
   endwhile
+  echom pline
   return pline
 endfunction
 

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -84,10 +84,10 @@ endfunction
 
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([match(pline,'.*[^/]\zs\/[/*]'),0])
+  let l:max = max([match(pline,'.*\zs\/\@<!\/[/*]'),0])
   while l:max && synIDattr(synID(a:ln, strlen(pline), 0), 'name') =~? 'comment\|doc'
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
-    let l:max = max([match(pline,'.*[^/]\zs\/[/*]'),0])
+    let l:max = max([match(pline,'.*\zs\/\@<!\/[/*]'),0])
   endwhile
   return pline
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -84,10 +84,10 @@ endfunction
 
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([match(pline,'.*\zs\/[/*]*'),0])
+  let l:max = max([match(pline,'.*\zs\/[/*]\+'),0])
   while l:max && synIDattr(synID(a:ln, strlen(pline), 0), 'name') =~? 'comment\|doc'
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
-    let l:max = max([match(pline,'.*\zs\/[/*]*'),0])
+    let l:max = max([match(pline,'.*\zs\/[/*]\+'),0])
   endwhile
   return pline
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -89,7 +89,6 @@ function s:Trim(ln)
     let pline = substitute(strpart(pline, 0, l:max),'\s*$','','')
     let l:max = max([match(pline,'.*\zs\/\@>[/*]'),0])
   endwhile
-  echom pline
   return pline
 endfunction
 


### PR DESCRIPTION
this fixes the edge case:
```
code = 'Neat' /// comment, through trimmed to a '/'
```