### PR TITLE
Add `jsFlowObjectValue` syntax region

### DIFF
--- a/extras/flow.vim
+++ b/extras/flow.vim
@@ -11,7 +11,8 @@ syntax region  jsFlowGroup          contained matchgroup=jsFlowNoise start=/</ e
 syntax region  jsFlowArrowArguments contained matchgroup=jsFlowNoise start=/(/  end=/)\%(\s*=>\)\@=/ oneline skipwhite skipempty nextgroup=jsFlowArrow contains=@jsFlowCluster
 syntax match   jsFlowArrow          contained /=>/ skipwhite skipempty nextgroup=jsFlowType,jsFlowTypeCustom,jsFlowParens
 syntax match   jsFlowMaybe          contained /?/ skipwhite skipempty nextgroup=jsFlowType,jsFlowTypeCustom,jsFlowParens,jsFlowArrowArguments
-syntax match   jsFlowObjectKey      contained /[0-9a-zA-Z_$?]*\(\s*:\)\@=/ contains=jsFunctionKey,jsFlowMaybe skipwhite skipempty nextgroup=jsObjectValue containedin=jsObject
+syntax match   jsFlowObjectKey      contained /[0-9a-zA-Z_$?]*\(\s*:\)\@=/ contains=jsFunctionKey,jsFlowMaybe skipwhite skipempty nextgroup=jsFlowObjectValue containedin=jsObject
+syntax region  jsFlowObjectValue    contained start=/:/ end=/\%(,\|;\|}\)\@=/ contains=jsObjectColon,@jsFlowCluster,@jsNoise extend
 syntax match   jsFlowOrOperator     contained /|/ skipwhite skipempty nextgroup=@jsFlowCluster
 
 syntax match   jsFlowReturn         contained /:\s*/ contains=jsFlowNoise skipwhite skipempty nextgroup=@jsFlowReturnCluster


### PR DESCRIPTION
Partial fix for #723, still having issues grabbing that last semi-colon as either `jsNoise` or `jsFlowNoise` but the type definition looks a lot better:

<img width="468" alt="screen shot 2016-11-21 at 11 14 34 am" src="https://cloud.githubusercontent.com/assets/18397/20490281/7377e0ca-afdb-11e6-8e35-0c81d5ac9df4.png">
