### PR TITLE
paren start line as baseline in blocks

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -97,18 +97,18 @@ let s:opfirst = '^' . get(g:,'javascript_opfirst',
 let s:continuation = get(g:,'javascript_continuation',
       \ '\%([<=,.?/*^%|&:]\|+\@<!+\|-\@<!-\|=\@<!>\|\<typeof\|\<in\%(stanceof\)\=\)') . '$'
 
-function s:controlFlow()
+function s:controlFlow(...)
   let token = s:previous_token()
   if index(split('await each'),token) + 1
     return s:previous_token() ==# 'for'
   endif
-  return index(split('switch for if let while with'),token)
+  return index(split('switch for if let while with'),token,a:0) + 1
 endfunction
 
 function s:OneScope(lnum,text)
   if cursor(a:lnum, match(' ' . a:text, ')$')) + 1 &&
         \ s:GetPair('(', ')', 'bW', s:skip_expr, 100) > 0
-    return s:controlFlow() > 0
+    return s:controlFlow(1)
   endif
   return cursor(a:lnum, match(' ' . a:text, '\%(\<else\|\<do\|=>\)$\C')) + 1
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -244,8 +244,9 @@ function GetJavascriptIndent()
             \ float2nr(str2float(matchstr(&cino,'.*:\zs[-0-9.]*')) * (&cino =~# '\%(.*:\)\@>[^,]*s' ? s:W : 1))
       if l:line =~# '^' . s:case_stmt
         return indent(num) + switch_offset
+      elseif pline =~# s:case_stmt . '$'
+        return indent(l:lnum) + s:W
       endif
-      let stmt = pline !~# s:case_stmt . '$'
     endif
   endif
 

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -2,7 +2,7 @@
 " Language: Javascript
 " Maintainer: Chris Paul ( https://github.com/bounceme )
 " URL: https://github.com/pangloss/vim-javascript
-" Last Change: November 20, 2016
+" Last Change: November 24, 2016
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -239,13 +239,16 @@ function GetJavascriptIndent()
   let [s:W, pline, isOp, stmt, bL, switch_offset] = [s:sw(), s:Trim(l:lnum),0,0,0,0]
   if num && paren == '{' && s:IsBlock()
     let stmt = 1
-    if s:looking_at() == ')' && s:GetPair('(', ')', 'bW', s:skip_expr, 100) > 0 && s:previous_token() ==# 'switch'
-      let switch_offset = &cino !~ ':' || !has('float') ? s:W :
-            \ float2nr(str2float(matchstr(&cino,'.*:\zs[-0-9.]*')) * (&cino =~# '\%(.*:\)\@>[^,]*s' ? s:W : 1))
-      if l:line =~# '^' . s:case_stmt
-        return indent(num) + switch_offset
-      elseif pline =~# s:case_stmt . '$'
-        return indent(l:lnum) + s:W
+    if s:looking_at() == ')' && s:GetPair('(', ')', 'bW', s:skip_expr, 100) > 0
+      let num = line('.')
+      if s:previous_token() ==# 'switch'
+        let switch_offset = &cino !~ ':' || !has('float') ? s:W :
+              \ float2nr(str2float(matchstr(&cino,'.*:\zs[-0-9.]*')) * (&cino =~# '\%(.*:\)\@>[^,]*s' ? s:W : 1))
+        if l:line =~# '^' . s:case_stmt
+          return indent(num) + switch_offset
+        elseif pline =~# s:case_stmt . '$'
+          return indent(l:lnum) + s:W
+        endif
       endif
     endif
   endif

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -93,7 +93,7 @@ endfunction
 
 " configurable regexes that define continuation lines, not including (, {, or [.
 let s:opfirst = '^' . get(g:,'javascript_opfirst',
-      \ '\%([<>,?^%|*/&]\|\([-.:+]\)\1\@!\|=>\@!\|typeof\>\|in\%(stanceof\)\=\>\)')
+      \ '\%([<>,?^%|*/&]\|\([-.:+]\)\1\@!\|!=\|=>\@!\|typeof\>\|in\%(stanceof\)\=\>\)')
 let s:continuation = get(g:,'javascript_continuation',
       \ '\%([<=,.?/*^%|&:]\|+\@<!+\|-\@<!-\|=\@<!>\|\<typeof\|\<in\%(stanceof\)\=\)') . '$'
 

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -251,8 +251,8 @@ function GetJavascriptIndent()
   endif
 
   let notlist = paren == '(' && s:controlFlow() || stmt
-  let isOp = l:line =~# substitute(s:opfirst,(notlist ? '' : ','),'','') ||
-        \ pline =~# substitute(s:continuation,(notlist ? '' : ','),'','') &&
+  let isOp = pline =~# (notlist ? s:continuation : substitute(s:continuation,',','','')) ||
+        \ l:line =~# (notlist ? s:opfirst : substitute(s:opfirst,',','','')) &&
         \ synIDattr(synID(l:lnum,match(' ' . pline,'\/$'),0),'name') !~? 'regex'
   if stmt || !num
     let bL = s:iscontOne(l:lnum,num,isOp)

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -102,13 +102,13 @@ function s:controlFlow()
   if index(split('await each'),token) + 1
     return s:previous_token() ==# 'for'
   endif
-  return index(split('switch for if let while with'),token) + 1
+  return index(split('switch for if let while with'),token)
 endfunction
 
 function s:OneScope(lnum,text)
   if cursor(a:lnum, match(' ' . a:text, ')$')) + 1 &&
         \ s:GetPair('(', ')', 'bW', s:skip_expr, 100) > 0
-    return s:controlFlow() > 1
+    return s:controlFlow() > 0
   endif
   return cursor(a:lnum, match(' ' . a:text, '\%(\<else\|\<do\|=>\)$\C')) + 1
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -251,9 +251,9 @@ function GetJavascriptIndent()
   endif
 
   let notlist = paren == '(' && s:controlFlow() || stmt
-  let isOp = pline =~# (notlist ? s:continuation : substitute(s:continuation,',','','')) ||
-        \ l:line =~# (notlist ? s:opfirst : substitute(s:opfirst,',','','')) &&
-        \ synIDattr(synID(l:lnum,match(' ' . pline,'\/$'),0),'name') !~? 'regex'
+  let isOp = pline =~# (notlist ? s:continuation : substitute(s:continuation,',','','')) &&
+        \ synIDattr(synID(l:lnum,match(' ' . pline,'\/$'),0),'name') !~? 'regex' ||
+        \ l:line =~# (notlist ? s:opfirst : substitute(s:opfirst,',','',''))
   if stmt || !num
     let bL = s:iscontOne(l:lnum,num,isOp)
     let bL -= (bL && l:line[0] == '{') * s:W


### PR DESCRIPTION
https://github.com/pangloss/vim-javascript/issues/683#issuecomment-255620211

@sassanh what do you think about this ? list-like things (arrays, ob literals, argument lists) will all now be indented extra when using operators besides the comma, and grouping parens are treated blocklike