### PR TITLE
Fix end pattern for import region

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -44,7 +44,7 @@ syntax keyword jsModuleOperators contained as
 syntax region  jsModuleGroup     contained matchgroup=jsModuleBraces start=/{/ end=/}/ contains=jsModuleOperators,jsNoise,jsComment
 syntax match   jsModuleAsterisk  contained /*/
 syntax keyword jsModuleDefault   contained default skipwhite skipempty nextgroup=@jsExpression
-syntax region  jsImportContainer start=/\<import\> / end="\%(;\|$\)" contains=jsModuleKeywords,jsModuleOperators,jsComment,jsString,jsTemplateString,jsNoise,jsModuleGroup,jsModuleAsterisk
+syntax region  jsImportContainer start=/\<import\>/ end=/\%("\|'\s*\)\@<=\%(;\|\n\)/ contains=jsModuleKeywords,jsModuleOperators,jsComment,jsString,jsTemplateString,jsNoise,jsModuleGroup,jsModuleAsterisk keepend
 syntax region  jsExportContainer start=/\<export\> / end="\%(;\|$\)" contains=jsModuleKeywords,jsModuleOperators,jsStorageClass,jsModuleDefault,@jsExpression
 syntax region  jsExportBlock     contained matchgroup=jsExportBraces start=/{/ end=/}/ contains=jsModuleOperators,jsNoise,jsComment
 


### PR DESCRIPTION
There was a bug where import regions required a semicolon, no longer.

This fixes issue #726