### PR TITLE
Add '0.' to 'indentkeys'

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -13,7 +13,7 @@ let b:did_indent = 1
 " Now, set up our indentation expression and keys that trigger it.
 setlocal indentexpr=GetJavascriptIndent()
 setlocal autoindent nolisp nosmartindent
-setlocal indentkeys=0{,0},0),0],:,!^F,o,O,e
+setlocal indentkeys=0{,0},0),0],:,!^F,o,O,e,0.
 
 let b:undo_indent = 'setlocal indentexpr< smartindent< autoindent< indentkeys<'
 


### PR DESCRIPTION
This will automatically indent when chaining methods on a new line.

__Example of when this is useful:__
You have this piece of code, where `|` represents the cursor:

```javascript
this.$http.get('/foo')
|
```

You type `.then(`

```javascript
this.$http.get('/foo')
    .then(|
```

The line got reindented when pressing `.`