### PR TITLE
optimization: no continuation at block start

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -248,7 +248,7 @@ function GetJavascriptIndent()
     let stmt = 1
   endif
 
-  if stmt || !num
+  if stmt && (b:js_cache[1] != l:lnum || pline[-1:] != '{') || !num
     let isOp = l:line =~# s:opfirst || pline =~# s:continuation &&
           \ synIDattr(synID(l:lnum,match(' ' . pline,'\/$'),0),'name') !~? 'regex'
     let bL = s:iscontOne(l:lnum,num,isOp)

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -248,7 +248,7 @@ function GetJavascriptIndent()
     let stmt = 1
   endif
 
-  if stmt && (b:js_cache[1] != l:lnum || pline[-1:] != '{') || !num
+  if stmt && pline[-1:] != '{' || !num
     let isOp = l:line =~# s:opfirst || pline =~# s:continuation &&
           \ synIDattr(synID(l:lnum,match(' ' . pline,'\/$'),0),'name') !~? 'regex'
     let bL = s:iscontOne(l:lnum,num,isOp)


### PR DESCRIPTION
Impossible to have a continuing line started after a block '{'