### PR TITLE
Added conceal for no-argument arrow functions - either `()=>` or `_=>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ global vim option, we do not set it ourselves.
 ## Concealing Characters
 
 You can customize concealing characters by defining one or more of the following
-variables:
+variables (these are all disabled by default):
 
     let g:javascript_conceal_function             = "ƒ"
     let g:javascript_conceal_null                 = "ø"
@@ -98,6 +98,16 @@ variables:
     let g:javascript_conceal_arrow_function       = "⇒"
     let g:javascript_conceal_noarg_arrow_function = "🞅"
     let g:javascript_conceal_underscore_arrow_function = "🞅"
+
+
+You can enable concealing within VIM with:
+
+    set conceallevel=1
+
+OR if you wish to toggle concealing you may wish to bind a command such as the following which will map LEADER+L (leader is usually the comma key) to toggling conceal mode:
+
+    map <leader>l :exec &conceallevel ? "set conceallevel=0" : "set conceallevel=1"<CR>
+
 
 ## Indentation Specific
 

--- a/README.md
+++ b/README.md
@@ -86,16 +86,17 @@ global vim option, we do not set it ourselves.
 You can customize concealing characters by defining one or more of the following
 variables:
 
-    let g:javascript_conceal_function       = "ƒ"
-    let g:javascript_conceal_null           = "ø"
-    let g:javascript_conceal_this           = "@"
-    let g:javascript_conceal_return         = "⇚"
-    let g:javascript_conceal_undefined      = "¿"
-    let g:javascript_conceal_NaN            = "ℕ"
-    let g:javascript_conceal_prototype      = "¶"
-    let g:javascript_conceal_static         = "•"
-    let g:javascript_conceal_super          = "Ω"
-    let g:javascript_conceal_arrow_function = "⇒"
+    let g:javascript_conceal_function             = "ƒ"
+    let g:javascript_conceal_null                 = "ø"
+    let g:javascript_conceal_this                 = "@"
+    let g:javascript_conceal_return               = "⇚"
+    let g:javascript_conceal_undefined            = "¿"
+    let g:javascript_conceal_NaN                  = "ℕ"
+    let g:javascript_conceal_prototype            = "¶"
+    let g:javascript_conceal_static               = "•"
+    let g:javascript_conceal_super                = "Ω"
+    let g:javascript_conceal_arrow_function       = "⇒"
+    let g:javascript_conceal_noarg_arrow_function = "🞅"
 
 ## Indentation Specific
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ variables:
     let g:javascript_conceal_super                = "Ω"
     let g:javascript_conceal_arrow_function       = "⇒"
     let g:javascript_conceal_noarg_arrow_function = "🞅"
+    let g:javascript_conceal_underscore_arrow_function = "🞅"
 
 ## Indentation Specific
 

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -173,6 +173,8 @@ syntax match   jsArrowFuncArgs  /([^()]*)\s*\(=>\)\@=/ contains=jsFuncArgs skipe
 
 exe 'syntax match jsFunction /\<function\>/ skipwhite skipempty nextgroup=jsGenerator,jsFuncName,jsFuncArgs skipwhite '.(exists('g:javascript_conceal_function')       ? 'conceal cchar='.g:javascript_conceal_function : '')
 exe 'syntax match jsArrowFunction /=>/      skipwhite skipempty nextgroup=jsFuncBlock,jsCommentFunction               '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')
+exe 'syntax match jsArrowFunction /_\s*\(=>\)\@=/    skipwhite skipempty nextgroup=jsArrowFunction                    '.(exists('g:javascript_conceal_noarg_arrow_function') ? 'conceal cchar='.g:javascript_conceal_noarg_arrow_function : '')
+exe 'syntax match jsArrowFunction /()\s*\(=>\)\@=/   skipwhite skipempty nextgroup=jsArrowFunction                    '.(exists('g:javascript_conceal_noarg_arrow_function') ? 'conceal cchar='.g:javascript_conceal_noarg_arrow_function : '')
 
 " Classes
 syntax keyword jsClassKeyword           contained class

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -173,8 +173,8 @@ syntax match   jsArrowFuncArgs  /([^()]*)\s*\(=>\)\@=/ contains=jsFuncArgs skipe
 
 exe 'syntax match jsFunction /\<function\>/ skipwhite skipempty nextgroup=jsGenerator,jsFuncName,jsFuncArgs skipwhite '.(exists('g:javascript_conceal_function')       ? 'conceal cchar='.g:javascript_conceal_function : '')
 exe 'syntax match jsArrowFunction /=>/      skipwhite skipempty nextgroup=jsFuncBlock,jsCommentFunction               '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')
-exe 'syntax match jsArrowFunction /_\s*\(=>\)\@=/    skipwhite skipempty nextgroup=jsArrowFunction                    '.(exists('g:javascript_conceal_noarg_arrow_function') ? 'conceal cchar='.g:javascript_conceal_noarg_arrow_function : '')
 exe 'syntax match jsArrowFunction /()\s*\(=>\)\@=/   skipwhite skipempty nextgroup=jsArrowFunction                    '.(exists('g:javascript_conceal_noarg_arrow_function') ? 'conceal cchar='.g:javascript_conceal_noarg_arrow_function : '')
+exe 'syntax match jsArrowFunction /_\s*\(=>\)\@=/    skipwhite skipempty nextgroup=jsArrowFunction                    '.(exists('g:javascript_conceal_underscore_arrow_function') ? 'conceal cchar='.g:javascript_conceal_underscore_arrow_function : '')
 
 " Classes
 syntax keyword jsClassKeyword           contained class


### PR DESCRIPTION
Setting `let g:javascript_conceal_noarg_arrow_function` to a character value conceals the characters before an arrow function. The syntax matcher also checks for whitespace after the `()` or `_` characters.

![screenshot_2016-11-27_11-25-41](https://cloud.githubusercontent.com/assets/624527/20644911/78777870-b494-11e6-81a9-d077b12c9439.png)

In the above screenshot the top half of the window shows the raw file and the bottom half shows the VI output when the following style is present in `~/.vimrc`:

```vimrc
let g:javascript_conceal_arrow_function = "🡆"
let g:javascript_conceal_noarg_arrow_function = "🞅"
set conceallevel=1
```
