### PR TITLE
package-manager info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ improved indentation.
 
       git clone https://github.com/pangloss/vim-javascript.git ~/.vim/bundle/vim-javascript
 
-### alternatively, use a package manager like [vim-plug](https://github.com/junegunn/vim-plug)
+#### alternatively, use a package manager like [vim-plug](https://github.com/junegunn/vim-plug)
 
 
 ## Configuration Variables

--- a/README.md
+++ b/README.md
@@ -6,31 +6,11 @@ improved indentation.
 
 ## Installation
 
-### Install with [Vundle](https://github.com/gmarik/vundle)
-
-Add to vimrc:
-
-    Plugin 'pangloss/vim-javascript'
-
-And install it:
-
-    :so ~/.vimrc
-    :PluginInstall
-
-### Install with [vim-plug](https://github.com/junegunn/vim-plug)
-
-Add to vimrc:
-
-    Plug 'pangloss/vim-javascript'
-
-And install it:
-
-    :so ~/.vimrc
-    :PlugInstall
-
 ### Install with [pathogen](https://github.com/tpope/vim-pathogen)
 
       git clone https://github.com/pangloss/vim-javascript.git ~/.vim/bundle/vim-javascript
+
+### alternatively, use a package manager like [vim-plug](https://github.com/junegunn/vim-plug)
 
 
 ## Configuration Variables

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ improved indentation.
 
       git clone https://github.com/pangloss/vim-javascript.git ~/.vim/bundle/vim-javascript
 
-#### alternatively, use a package manager like [vim-plug](https://github.com/junegunn/vim-plug)
+alternatively, use a package manager like [vim-plug](https://github.com/junegunn/vim-plug)
 
 
 ## Configuration Variables

--- a/README.md
+++ b/README.md
@@ -104,11 +104,6 @@ maintainer(s) then, hopefully, merged.
 Thank you!
 
 
-## Bug Reports
-
-Report a bug on [GitHub Issues](https://github.com/pangloss/vim-javascript/issues).
-
-
 ## License
 
 Distributed under the same terms as Vim itself. See `:help license`.


### PR DESCRIPTION
removes some of that fairly useless info, which was taking all space 'above the fold'. @amadeus ?