### PR TITLE
imporve syntax for jsClassValue

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -183,7 +183,7 @@ syntax match   jsClassNoise             contained /\./
 syntax match   jsClassMethodType        contained /\%(get\|set\|static\|async\)\%( \k\+\)\@=/ skipwhite skipempty nextgroup=jsFuncName,jsClassProperty
 syntax region  jsClassDefinition                  start=/\<class\>/ end=/\(\<extends\>\s\+\)\@<!{\@=/ contains=jsClassKeyword,jsExtendsKeyword,jsClassNoise,@jsExpression skipwhite skipempty nextgroup=jsCommentClass,jsClassBlock,jsFlowClassGroup
 syntax match   jsClassProperty          contained /\<[0-9a-zA-Z_$]*\>\(\s*=\)\@=/ skipwhite skipempty nextgroup=jsClassValue
-syntax region  jsClassValue             contained start=/=/ end=/\%(;\|}\|\n\)\@=/ contains=@jsExpression
+syntax region  jsClassValue             contained start=/=/ end=/\%(;\|}\|\n\)\@=/ keepend contains=@jsExpression
 syntax region  jsClassPropertyComputed  contained matchgroup=jsBrackets start=/\[/ end=/]/ contains=@jsExpression skipwhite skipempty nextgroup=jsFuncArgs,jsClassValue extend
 syntax match   jsClassFuncName          contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\%(\s*(\)\@=/ skipwhite skipempty nextgroup=jsFuncArgs
 syntax region  jsClassStringKey         contained start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@Spell extend skipwhite skipempty nextgroup=jsFuncArgs


### PR DESCRIPTION
<img width="306" alt="screen shot 2016-12-14 at 12 30 54 am" src="https://cloud.githubusercontent.com/assets/251450/21149161/8a9999bc-c195-11e6-93d5-f004928bcae3.png">

`jsClassValue` not works well with `jsDecorator` without end comma.
This patch add keepend to avoid that problem.

There could be better way to fix this, since `keepend` would prevent the highlight of `jsClassValue` cross lines.