### PR TITLE
Improve @typedef syntax for namepath.

### DIFF
--- a/extras/jsdoc.vim
+++ b/extras/jsdoc.vim
@@ -4,9 +4,9 @@ syntax region jsComment    matchgroup=jsComment start="/\*\s*"  end="\*/" contai
 " tags containing a param
 syntax match  jsDocTags         contained "@\(alias\|api\|augments\|borrows\|class\|constructs\|default\|defaultvalue\|emits\|exception\|exports\|extends\|fires\|kind\|link\|listens\|member\|member[oO]f\|mixes\|module\|name\|namespace\|requires\|template\|throws\|var\|variation\|version\)\>" skipwhite nextgroup=jsDocParam
 " tags containing type and param
-syntax match  jsDocTags         contained "@\(arg\|argument\|cfg\|param\|property\|prop\)\>" skipwhite nextgroup=jsDocType
+syntax match  jsDocTags         contained "@\(arg\|argument\|cfg\|param\|property\|prop\|typedef\)\>" skipwhite nextgroup=jsDocType
 " tags containing type but no param
-syntax match  jsDocTags         contained "@\(callback\|define\|enum\|external\|implements\|this\|type\|typedef\|return\|returns\)\>" skipwhite nextgroup=jsDocTypeNoParam
+syntax match  jsDocTags         contained "@\(callback\|define\|enum\|external\|implements\|this\|type\|return\|returns\)\>" skipwhite nextgroup=jsDocTypeNoParam
 " tags containing references
 syntax match  jsDocTags         contained "@\(lends\|see\|tutorial\)\>" skipwhite nextgroup=jsDocSeeTag
 " other tags (no extra syntax)


### PR DESCRIPTION
Currently @typedef is not highlighting the `<namepath>` argument (http://usejsdoc.org/tags-typedef.html) when defining new types.  This adds the highlight rule applied tags like @param which also disables the spellcheck.

Before (note red highlight in this theme indicates misspelled word):

<img width="285" alt="screen shot 2016-12-31 at 9 58 17 pm" src="https://cloud.githubusercontent.com/assets/26638/21580136/4381dff4-cfa4-11e6-80a7-a1fe7fa3867d.png">


After:

<img width="331" alt="screen shot 2016-12-31 at 9 56 02 pm" src="https://cloud.githubusercontent.com/assets/26638/21580135/1a680076-cfa4-11e6-8c13-b07296c56e78.png">
