### PR TITLE
check for lines which contain at least 2 `/`

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -61,7 +61,8 @@ function s:skip_func()
     return !s:free
   endif
   let s:looksyn = line('.')
-  return (search('\m\/','nbW',s:looksyn) || search('\m[''"]\|\\$','nW',s:looksyn)) && eval(s:skip_expr)
+  return (search('\m[''"]\|\\$','nW',s:looksyn) || getline('.') =~ '\/\%(.*\/\)\@=.*\%'.col('.').'c') &&
+        \ eval(s:skip_expr)
 endfunction
 
 function s:alternatePair(stop)


### PR DESCRIPTION
more potential time saving, must have one `/` to the left of pos and at least two `/` in the line

an example of the benefit is not forcing a check when the line only has a division operator,

```
/ (|)
(|) //
``` 
won't check
```
// (|)
/(|)/
```
will