### PR TITLE
cleaning,search flags

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -55,14 +55,12 @@ let s:syng_com = 'comment\|doc'
 let s:skip_expr = "synIDattr(synID(line('.'),col('.'),0),'name') =~? '".s:syng_strcom."'"
 
 function s:skip_func()
-  if !s:free || search('\m`\|\*\/','nW',s:looksyn)
+  if !s:free || search('\m`\|\*\/','znW',s:looksyn)
     let s:free = !eval(s:skip_expr)
-    let s:looksyn = s:free ? line('.') : s:looksyn
-    return !s:free
   endif
   let s:looksyn = line('.')
-  return (search('\m[''"]\|\\$','nW',s:looksyn) || getline('.') =~ '\/\%<'.(col('.')+1).'c.\{-}\/') &&
-        \ eval(s:skip_expr)
+  return !s:free || ((search('\m[''"]\|\\$','znW',s:looksyn) || getline('.') =~ '\/\%<'.(col('.')+1).'c.\{-}\/') &&
+        \ eval(s:skip_expr))
 endfunction
 
 function s:alternatePair(stop)

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -57,10 +57,12 @@ let s:skip_expr = "synIDattr(synID(line('.'),col('.'),0),'name') =~? '".s:syng_s
 function s:skip_func()
   if !s:free || search('\m`\|\*\/','znW',s:looksyn)
     let s:free = !eval(s:skip_expr)
+    let s:looksyn = line('.')
+    return !s:free
   endif
   let s:looksyn = line('.')
-  return !s:free || ((search('\m[''"]\|\\$','znW',s:looksyn) || getline('.') =~ '\/\%<'.(col('.')+1).'c.\{-}\/') &&
-        \ eval(s:skip_expr))
+  return (search('\m[''"]\|\\$','znW',s:looksyn) || getline('.') =~ '\/\%<'.(col('.')+1).'c.\{-}\/') &&
+        \ eval(s:skip_expr)
 endfunction
 
 function s:alternatePair(stop)


### PR DESCRIPTION
the use case of the z flag is for forward searching were it seems equivalent, or, backwards searching starting at the previous line. It is faster