### PR TITLE
add compiler plugin

### DIFF
--- a/compiler/eslint.vim
+++ b/compiler/eslint.vim
@@ -8,4 +8,4 @@ if exists(":CompilerSet") != 2
 endif
 
 CompilerSet makeprg=eslint\ -f\ compact\ %
-CompilerSet errorformat=%E%f:\ line\ %l\\,\ col\ %c\\,\ Error\ -\ %m,%W%f:\ line\ %l\\,\ col\ %c\\,\ Warning\ -\ %m
+CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/compiler/eslint.vim
+++ b/compiler/eslint.vim
@@ -1,0 +1,11 @@
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "eslint"
+
+if exists(":CompilerSet") != 2
+  command! -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=eslint\ -f\ compact\ %
+CompilerSet errorformat=%E%f:\ line\ %l\\,\ col\ %c\\,\ Error\ -\ %m,%W%f:\ line\ %l\\,\ col\ %c\\,\ Warning\ -\ %m


### PR DESCRIPTION
adds eslint as a compiler for javascript files. It is used like:
`:compiler eslint` then `:make`
Most people already use plugins like neomake or syntastic, and i don't think this should be anything but a sensible fallback, i.e. not really interested in p.r.s adding different linters/styleguides etc.