### PR TITLE
First pass at jsObjectProp

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -24,7 +24,8 @@ syntax sync fromstart
 " syntax case ignore
 syntax case match
 
-syntax match   jsNoise          /[:,\;\.]\{1}/
+syntax match   jsNoise          /[:,\;]\{1}/
+syntax match   jsNoise          /[\.]\{1}/ skipwhite skipempty nextgroup=jsObjectProp
 syntax match   jsFuncCall       /\k\+\%(\s*(\)\@=/
 syntax match   jsParensError    /[)}\]]/
 
@@ -220,6 +221,7 @@ syntax region  jsCommentMisc        contained start=/\/\*/ end=/\*\// contains=j
 " Decorators
 syntax match   jsDecorator                    /^\s*@/ nextgroup=jsDecoratorFunction
 syntax match   jsDecoratorFunction  contained /[a-zA-Z_][a-zA-Z0-9_.]*/ nextgroup=jsParenDecorator
+syntax match   jsObjectProp         contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>/
 
 if exists("javascript_plugin_jsdoc")
   runtime extras/jsdoc.vim


### PR DESCRIPTION
I had an interesting idea to disable various matches like `class` and `require` from appearing when using `.` notation on objects (e.g. in `obj.class`, the `class` prop should not match as a class definition).

The proposed fix is to create a special `jsObjectProp` match, with a super high priority, that is used as a `nextgroup` for `.`

It is not assigned any colors or match groups, it simply exists to disable other items from matching.

This is a very quick pass and I have not really tested it yet, but I think it could be a very viable, working solution