### PR TITLE
safer GetPair condition

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -71,7 +71,7 @@ function s:alternatePair(stop)
     if !s:skip_func()
       let idx = stridx('])}',s:looking_at())
       if idx + 1
-        if !s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop)
+        if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) <= 0
           break
         endif
       else


### PR DESCRIPTION
searchpair can return `-1` if it fails from an error, which should be considered falsy return value