### PR TITLE
reimplement Trim()

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -177,10 +177,10 @@ endfunction
 " non-comment char.
 function s:Trim(ln)
   let pline = substitute(getline(a:ln),'\s*$','','')
-  let l:max = max([strridx(pline,'//'),strridx(pline,'/*'),0])
-  while l:max && s:syn_at(a:ln, strlen(pline)) =~? s:syng_com
+  let l:max = max([strridx(pline,'//'), strridx(pline,'/*')])
+  while l:max != -1 && s:syn_at(a:ln, strlen(pline)) =~? s:syng_com
     let pline = pline[: l:max]
-    let l:max = max([strridx(pline,'//'),strridx(pline,'/*'),0])
+    let l:max = max([strridx(pline,'//'), strridx(pline,'/*')])
     let pline = substitute(pline[:-2],'\s*$','','')
   endwhile
   return cursor(a:ln,strlen(pline)) ? pline : pline

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -176,9 +176,14 @@ endfunction
 " get the line of code stripped of comments and move cursor to the last
 " non-comment char.
 function s:Trim(ln)
-  call cursor(a:ln+1,1)
-  call s:previous_token()
-  return strpart(getline('.'),0,col('.'))
+  let pline = substitute(getline(a:ln),'\s*$','','')
+  let l:max = max([strridx(pline,'//'),strridx(pline,'/*'),0])
+  while l:max && s:syn_at(a:ln, strlen(pline)) =~? s:syng_com
+    let pline = pline[: l:max]
+    let l:max = max([strridx(pline,'//'),strridx(pline,'/*'),0])
+    let pline = substitute(pline[:-2],'\s*$','','')
+  endwhile
+  return cursor(a:ln,strlen(pline)) ? pline : pline
 endfunction
 
 " Find line above 'lnum' that isn't empty or in a comment

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -183,7 +183,7 @@ function s:Trim(ln)
     let l:max = max([strridx(pline,'//'), strridx(pline,'/*')])
     let pline = substitute(pline[:-2],'\s*$','','')
   endwhile
-  return cursor(a:ln,strlen(pline)) ? pline : pline
+  return pline is '' || cursor(a:ln,strlen(pline)) ? pline : pline
 endfunction
 
 " Find line above 'lnum' that isn't empty or in a comment


### PR DESCRIPTION
uses older version, only, as accurate as the current and faster than what is current