### PR TITLE
explicit match of cino parse

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -64,8 +64,8 @@ let s:skip_expr = "synIDattr(synID(line('.'),col('.'),0),'name') =~? '".s:syng_s
 
 function s:parse_cino(f) abort
   return float2nr(eval(substitute(substitute(join(split(
-        \ matchstr(&cino,'\C.*'.a:f.'\zs[^,]*'), 's',1), '*'.s:W)
-        \ , '^-\=\zs\*','',''), '^-\=\zs\.','0.','')))
+        \ matchstr(&cino,'\C.*'.a:f.'\zs-\=\d*\%(\.\d\+\)\=s\=')
+        \ , 's',1), '*'.s:W), '^-\=\zs\*','',''), '^-\=\zs\.','0.','')))
 endfunction
 
 function s:skip_func()


### PR DESCRIPTION
this matches only valid cino values. the eval'ing should be regulated