### PR TITLE
add "es" extension

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,4 +1,4 @@
-au BufNewFile,BufRead *.{js,jsm,es6},Jakefile setf javascript
+au BufNewFile,BufRead *.{js,jsm,es,es6},Jakefile setf javascript
 
 fun! s:SourceFlowSyntax()
   if !exists('javascript_plugin_flow') && !exists('b:flow_active') &&


### PR DESCRIPTION
https://github.com/vim/vim/blob/master/runtime/filetype.vim#L1019 already in vim proper. still i wonder why people do this