### PR TITLE
break search at col:1

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -92,19 +92,19 @@ function s:parse_cino(f)
 endfunction
 
 function s:skip_func()
-  if b:topCol == 1
+  if s:topCol == 1
     return {}
   endif
-  let b:topCol = col('.')
-  if getline('.') =~ '\%<'.b:topCol.'c\/.\{-}\/\|\%>'.b:topCol.'c[''"]\|\\$'
+  let s:topCol = col('.')
+  if getline('.') =~ '\%<'.s:topCol.'c\/.\{-}\/\|\%>'.s:topCol.'c[''"]\|\\$'
     if eval(s:skip_expr)
-      let b:topCol = 0
+      let s:topCol = 0
     endif
-    return !b:topCol
+    return !s:topCol
   elseif s:checkIn || search('\m`\|\${\|\*\/','nW'.s:z,s:looksyn)
     let s:checkIn = eval(s:skip_expr)
     if s:checkIn
-      let b:topCol = 0
+      let s:topCol = 0
     endif
   endif
   let s:looksyn = line('.')
@@ -381,13 +381,13 @@ function GetJavascriptIndent()
   endif
 
   " the containing paren, bracket, or curly. Many hacks for performance
-  let [ s:scriptTag, idx, b:topCol ] = [ get(get(b:,'hi_indent',{}),'blocklnr'),
-        \ index([']',')','}'],l:line[0]), 0 ]
+  let [ s:scriptTag, idx ] = [ get(get(b:,'hi_indent',{}),'blocklnr'),
+        \ index([']',')','}'],l:line[0]) ]
   if b:js_cache[0] >= l:lnum && b:js_cache[0] < v:lnum &&
         \ (b:js_cache[0] > l:lnum || s:Balanced(l:lnum))
     call call('cursor',b:js_cache[2] ? b:js_cache[1:] : [0,0])
   else
-    let [s:looksyn, s:checkIn] = [v:lnum - 1, 0]
+    let [s:looksyn, s:checkIn, s:topCol] = [v:lnum - 1, 0, 0]
     if idx + 1
       call s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:skip_func()',2000)
     elseif getline(v:lnum) !~ '^\S' && syns =~? 'block'

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -114,7 +114,6 @@ endfunction
 
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
-  try
   while search('\m'.pat,'bW',a:stop)
     if s:skip_func() | continue | endif
     let idx = stridx('])};',s:looking_at())
@@ -131,8 +130,6 @@ function s:alternatePair(stop)
       return
     endif
   endwhile
-  catch
-  endtry
   call call('cursor',pos)
 endfunction
 
@@ -386,9 +383,7 @@ function GetJavascriptIndent()
   let idx = index([']',')','}'],l:line[0])
   if b:js_cache[0] >= l:lnum && b:js_cache[0] < v:lnum &&
         \ (b:js_cache[0] > l:lnum || s:Balanced(l:lnum))
-    if b:js_cache[2]
-      call call('cursor',b:js_cache[1:])
-    endif
+    call call('cursor',b:js_cache[2] ? b:js_cache[1:] : [0,0])
   else
     let [s:looksyn, s:checkIn, top] = [v:lnum - 1, 0, max([s:scriptTag,
           \ (!indent(l:lnum) && s:syn_at(l:lnum,1) !~? s:syng_str) * l:lnum])]

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -93,7 +93,7 @@ endfunction
 
 function s:skip_func()
   if s:topCol == 1
-    return {}
+    return {} " :break, for searchpair() condition expression
   endif
   let s:topCol = col('.')
   if getline('.') =~ '\%<'.s:topCol.'c\/.\{-}\/\|\%>'.s:topCol.'c[''"]\|\\$'

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -115,12 +115,12 @@ endfunction
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
   while search('\m'.pat,'bW',a:stop)
-    silent! let not = s:skip_func()
-    if !exists('b:topCol')
+    try
+      let not = s:skip_func()
+    catch
       break
-    elseif not
-      continue
-    endif
+    endtry
+    if not | continue | endif
     let idx = stridx('])};',s:looking_at())
     if idx is 3
       if l:for is 1

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -114,13 +114,7 @@ endfunction
 
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
-  while search('\m'.pat,'bW',a:stop)
-    try
-      let not = s:skip_func()
-    catch
-      break
-    endtry
-    if not | continue | endif
+  while searchpair('\m'.pat,'','\_$.','bW','s:skip_func()',a:stop) > 0
     let idx = stridx('])};',s:looking_at())
     if idx is 3
       if l:for is 1

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -115,20 +115,24 @@ endfunction
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
   while search('\m'.pat,'bW',a:stop)
-    if s:skip_func() | continue | endif
-    let idx = stridx('])};',s:looking_at())
-    if idx is 3
-      if l:for is 1
-        return s:GetPair('{','}','bW','s:skip_func()',2000,a:stop) > 0 || call('cursor',pos)
+    try
+    if !s:skip_func()
+      let idx = stridx('])};',s:looking_at())
+      if idx is 3
+        if l:for is 1
+          return s:GetPair('{','}','bW','s:skip_func()',2000,a:stop) > 0 || call('cursor',pos)
+        endif
+        let [pat, l:for] = ['[{}();]', l:for - 1]
+      elseif idx + 1
+        if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) < 1
+          break
+        endif
+      else
+        return
       endif
-      let [pat, l:for] = ['[{}();]', l:for - 1]
-    elseif idx + 1
-      if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) < 1
-        break
-      endif
-    else
-      return
     endif
+  catch
+  endtry
   endwhile
   call call('cursor',pos)
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -93,7 +93,7 @@ endfunction
 
 function s:skip_func()
   if b:topCol == 1
-    throw 'no match'
+    return {}
   endif
   let b:topCol = col('.')
   if getline('.') =~ '\%<'.b:topCol.'c\/.\{-}\/\|\%>'.b:topCol.'c[''"]\|\\$'
@@ -114,12 +114,10 @@ endfunction
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
   while search('\m'.pat,'bW',a:stop)
-    try
-      let not = s:skip_func()
-    catch
+    let not = s:skip_func()
+    if type(not) == type({})
       break
-    endtry
-    if not | continue | endif
+    elseif not | continue | endif
     let idx = stridx('])};',s:looking_at())
     if idx is 3
       if l:for is 1
@@ -389,8 +387,7 @@ function GetJavascriptIndent()
         \ (b:js_cache[0] > l:lnum || s:Balanced(l:lnum))
     call call('cursor',b:js_cache[2] ? b:js_cache[1:] : [0,0])
   else
-    let [s:looksyn, s:checkIn, top] = [v:lnum - 1, 0, max([s:scriptTag,
-          \ (!indent(l:lnum) && s:syn_at(l:lnum,1) !~? s:syng_str) * l:lnum])]
+    let [s:looksyn, s:checkIn, top] = [v:lnum - 1, 0, 0]
     if idx + 1
       call s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:skip_func()',2000,top)
     elseif getline(v:lnum) !~ '^\S' && syns =~? 'block'

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -93,7 +93,7 @@ endfunction
 
 function s:skip_func()
   if s:topCol == 1
-    return {} " :break, causes typeError in searchpair()
+    return {} " :break, causes E731 in searchpair()
   endif
   let s:topCol = col('.')
   if getline('.') =~ '\%<'.s:topCol.'c\/.\{-}\/\|\%>'.s:topCol.'c[''"]\|\\$'

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -111,9 +111,9 @@ function s:skip_func()
   return s:checkIn
 endfunction
 
-function s:alternatePair(stop)
+function s:alternatePair()
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
-  while search('\m'.pat,'bW',a:stop)
+  while search('\m'.pat,'bW')
     let not = s:skip_func()
     if type(not) == type({})
       break
@@ -121,11 +121,11 @@ function s:alternatePair(stop)
     let idx = stridx('])};',s:looking_at())
     if idx is 3
       if l:for is 1
-        return s:GetPair('{','}','bW','s:skip_func()',2000,a:stop) > 0 || call('cursor',pos)
+        return s:GetPair('{','}','bW','s:skip_func()',2000) > 0 || call('cursor',pos)
       endif
       let [pat, l:for] = ['[{}();]', l:for - 1]
     elseif idx + 1
-      if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) < 1
+      if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000) < 1
         break
       endif
     else
@@ -387,13 +387,13 @@ function GetJavascriptIndent()
         \ (b:js_cache[0] > l:lnum || s:Balanced(l:lnum))
     call call('cursor',b:js_cache[2] ? b:js_cache[1:] : [0,0])
   else
-    let [s:looksyn, s:checkIn, top] = [v:lnum - 1, 0, 0]
+    let [s:looksyn, s:checkIn] = [v:lnum - 1, 0]
     if idx + 1
-      call s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:skip_func()',2000,top)
+      call s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:skip_func()',2000)
     elseif getline(v:lnum) !~ '^\S' && syns =~? 'block'
-      call s:GetPair('{','}','bW','s:skip_func()',2000,top)
+      call s:GetPair('{','}','bW','s:skip_func()',2000)
     else
-      call s:alternatePair(top)
+      call s:alternatePair()
     endif
   endif
 

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -92,7 +92,7 @@ function s:parse_cino(f)
 endfunction
 
 function s:skip_func()
-  if b:topCol = 1
+  if b:topCol == 1
     throw 'no match'
   endif
   let b:topCol = col('.')

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -115,7 +115,12 @@ endfunction
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
   while search('\m'.pat,'bW',a:stop)
-    silent! if s:skip_func() | continue | endif
+    silent! let not = s:skip_func()
+    if !exists('b:topCol')
+      break
+    elseif not
+      continue
+    endif
     let idx = stridx('])};',s:looking_at())
     if idx is 3
       if l:for is 1

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -93,7 +93,7 @@ endfunction
 
 function s:skip_func()
   if s:topCol == 1
-    return {} " :break, for searchpair() condition expression
+    return {} " :break, causes typeError in searchpair()
   endif
   let s:topCol = col('.')
   if getline('.') =~ '\%<'.s:topCol.'c\/.\{-}\/\|\%>'.s:topCol.'c[''"]\|\\$'

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -115,24 +115,20 @@ endfunction
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
   while search('\m'.pat,'bW',a:stop)
-    try
-    if !s:skip_func()
-      let idx = stridx('])};',s:looking_at())
-      if idx is 3
-        if l:for is 1
-          return s:GetPair('{','}','bW','s:skip_func()',2000,a:stop) > 0 || call('cursor',pos)
-        endif
-        let [pat, l:for] = ['[{}();]', l:for - 1]
-      elseif idx + 1
-        if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) < 1
-          break
-        endif
-      else
-        return
+    silent! if s:skip_func() | continue | endif
+    let idx = stridx('])};',s:looking_at())
+    if idx is 3
+      if l:for is 1
+        return s:GetPair('{','}','bW','s:skip_func()',2000,a:stop) > 0 || call('cursor',pos)
       endif
+      let [pat, l:for] = ['[{}();]', l:for - 1]
+    elseif idx + 1
+      if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) < 1
+        break
+      endif
+    else
+      return
     endif
-  catch
-  endtry
   endwhile
   call call('cursor',pos)
 endfunction

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -114,7 +114,13 @@ endfunction
 
 function s:alternatePair(stop)
   let [pos, pat, l:for] = [getpos('.')[1:2], '[][(){};]', 3]
-  while searchpair('\m'.pat,'','\_$.','bW','s:skip_func()',a:stop) > 0
+  while search('\m'.pat,'bW',a:stop)
+    try
+      let not = s:skip_func()
+    catch
+      break
+    endtry
+    if not | continue | endif
     let idx = stridx('])};',s:looking_at())
     if idx is 3
       if l:for is 1

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -92,8 +92,7 @@ function s:parse_cino(f)
 endfunction
 
 function s:skip_func()
-  if get(b:,'topCol') == 1
-    unlet b:topCol
+  if b:topCol = 1
     throw 'no match'
   endif
   let b:topCol = col('.')
@@ -384,8 +383,8 @@ function GetJavascriptIndent()
   endif
 
   " the containing paren, bracket, or curly. Many hacks for performance
-  let s:scriptTag = get(get(b:,'hi_indent',{}),'blocklnr')
-  let idx = index([']',')','}'],l:line[0])
+  let [ s:scriptTag, idx, b:topCol ] = [ get(get(b:,'hi_indent',{}),'blocklnr'),
+        \ index([']',')','}'],l:line[0]), 0 ]
   if b:js_cache[0] >= l:lnum && b:js_cache[0] < v:lnum &&
         \ (b:js_cache[0] > l:lnum || s:Balanced(l:lnum))
     call call('cursor',b:js_cache[2] ? b:js_cache[1:] : [0,0])

--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -2,7 +2,7 @@
 " Language: Javascript
 " Maintainer: Chris Paul ( https://github.com/bounceme )
 " URL: https://github.com/pangloss/vim-javascript
-" Last Change: May 2, 2017
+" Last Change: May 4, 2017
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')


### PR DESCRIPTION
https://github.com/guns/vim-sexp/blob/master/autoload/sexp.vim#L126

main difference is that we break whenever we are beyond a col:1 `[\[\](){}]`