### PR TITLE
Syntax highlight separately module alias source

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -40,15 +40,18 @@ syntax keyword jsBooleanTrue    true
 syntax keyword jsBooleanFalse   false
 
 " Modules
-syntax keyword jsImport                       import skipwhite skipempty nextgroup=jsModuleAsterisk,jsModuleKeyword,jsModuleGroup,jsFlowImportType
-syntax keyword jsExport                       export skipwhite skipempty nextgroup=@jsAll,jsModuleGroup,jsExportDefault,jsModuleAsterisk,jsModuleKeyword,jsFlowTypeStatement
+syntax keyword jsImport                       import skipwhite skipempty nextgroup=jsModuleAliasSrc,jsModuleKeyword,jsModuleGroup,jsFlowImportType
+syntax keyword jsExport                       export skipwhite skipempty nextgroup=@jsAll,jsModuleGroup,jsExportDefault,jsModuleAliasSrc,jsModuleKeyword,jsFlowTypeStatement
 syntax match   jsModuleKeyword      contained /\k\+/ skipwhite skipempty nextgroup=jsModuleAs,jsFrom,jsModuleComma
 syntax keyword jsExportDefault      contained default skipwhite skipempty nextgroup=@jsExpression
 syntax keyword jsExportDefaultGroup contained default skipwhite skipempty nextgroup=jsModuleAs,jsFrom,jsModuleComma
-syntax match   jsModuleAsterisk     contained /\*/ skipwhite skipempty nextgroup=jsModuleKeyword,jsModuleAs,jsFrom
+syntax match   jsModuleAliasSrc     contained /\%(\*\|\k\+\)\%(\s\+as\)\@=/ skipwhite skipempty nextgroup=jsModuleAs
 syntax keyword jsModuleAs           contained as skipwhite skipempty nextgroup=jsModuleKeyword,jsExportDefaultGroup
 syntax keyword jsFrom               contained from skipwhite skipempty nextgroup=jsString
-syntax match   jsModuleComma        contained /,/ skipwhite skipempty nextgroup=jsModuleKeyword,jsModuleAsterisk,jsModuleGroup,jsFlowTypeKeyword
+syntax match   jsModuleComma        contained /,/ skipwhite skipempty nextgroup=jsModuleKeyword,jsModuleAliasSrc,jsModuleGroup,jsFlowTypeKeyword
+" Because the groupname jsModuleAsterisk was updated to jsModuleAliasSrc, to
+" not break previous highlighting using that group it will be linked together.
+hi link jsModuleAliasSrc jsModuleAsterisk
 
 " Strings, Templates, Numbers
 syntax region  jsString           start=+"+  skip=+\\\("\|$\)+  end=+"\|$+  contains=jsSpecial,@Spell extend
@@ -159,7 +162,7 @@ syntax region  jsDestructuringBlock contained matchgroup=jsDestructuringBraces s
 syntax region  jsDestructuringArray contained matchgroup=jsDestructuringBraces start=/\[/ end=/\]/ contains=jsDestructuringPropertyValue,jsNoise,jsDestructuringProperty,jsSpreadExpression,jsComment extend fold
 syntax region  jsObject             contained matchgroup=jsObjectBraces        start=/{/  end=/}/  contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectMethodType,jsGenerator,jsComment,jsObjectStringKey,jsSpreadExpression,jsDecorator,jsAsyncKeyword extend fold
 syntax region  jsBlock                        matchgroup=jsBraces              start=/{/  end=/}/  contains=@jsAll,jsSpreadExpression extend fold
-syntax region  jsModuleGroup        contained matchgroup=jsModuleBraces        start=/{/ end=/}/   contains=jsModuleKeyword,jsModuleComma,jsModuleAs,jsComment,jsFlowTypeKeyword skipwhite skipempty nextgroup=jsFrom fold
+syntax region  jsModuleGroup        contained matchgroup=jsModuleBraces        start=/{/ end=/}/   contains=jsModuleAliasSrc,jsModuleKeyword,jsModuleComma,jsModuleAs,jsComment,jsFlowTypeKeyword skipwhite skipempty nextgroup=jsFrom fold
 syntax region  jsSpreadExpression   contained matchgroup=jsSpreadOperator      start=/\.\.\./ end=/[,}\]]\@=/ contains=@jsExpression
 syntax region  jsRestExpression     contained matchgroup=jsRestOperator        start=/\.\.\./ end=/[,)]\@=/
 syntax region  jsTernaryIf                    matchgroup=jsTernaryIfOperator   start=/?/  end=/\%(:\|[\}]\@=\)/  contains=@jsExpression extend skipwhite skipempty nextgroup=@jsExpression


### PR DESCRIPTION
It creates a new syntax group name called: `jsModuleAliasSrc` which covers the separate highlighting of the source of an aliased import/export like in the following examples:
```javascript
import * as member1 from 'source'
import member2 as mb2 from 'source'
import member3, member4 as mb4 from 'source'
import member5, { member6 as mb6 } from 'source'

const mb7 = true

export mb7 as member7
```

All of the following elements will be highlighted using the `jsModuleAlisSrc` group name.
- `*`
- `member2`
- `member4`
- `member6`
- `mb7`

Also the `jsModuleAsterisk` group name is removed but linked with the new group to not break previous color schemes using it.

**TL;DR Reasoning:**
I am currently building a vim syntax highlight and color scheme for Typescript based on this project, which I found extremely well made and organized. While selecting colors I noticed that I couldn't control the color of the alias source which in my opinion is not as meaningful at a glance as the alias which is used in the code as a local variable, giving it more priority colorwise. So I decided to make this modification which I thought it could be useful for the project. Cheers!