### PR TITLE
Add WeakSet to syntax keywords

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -110,7 +110,7 @@ syntax keyword jsAsyncKeyword           async await
 syntax match   jsSwitchColon   contained /::\@!/        skipwhite skipempty nextgroup=jsSwitchBlock
 
 " Keywords
-syntax keyword jsGlobalObjects      Array Boolean Date Function Iterator Number Object Symbol Map WeakMap Set RegExp String Proxy Promise Buffer ParallelArray ArrayBuffer DataView Float32Array Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array Uint8Array Uint8ClampedArray JSON Math console document window Intl Collator DateTimeFormat NumberFormat fetch
+syntax keyword jsGlobalObjects      Array Boolean Date Function Iterator Number Object Symbol Map WeakMap Set WeakSet RegExp String Proxy Promise Buffer ParallelArray ArrayBuffer DataView Float32Array Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array Uint8Array Uint8ClampedArray JSON Math console document window Intl Collator DateTimeFormat NumberFormat fetch
 syntax keyword jsGlobalNodeObjects  module exports global process __dirname __filename
 syntax match   jsGlobalNodeObjects  /\<require\>/ containedin=jsFuncCall
 syntax keyword jsExceptions         Error EvalError InternalError RangeError ReferenceError StopIteration SyntaxError TypeError URIError


### PR DESCRIPTION
Add [WeakSet](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/WeakSet) to the list of jsGlobalObjects keywords.

> ⚠️ I have to mention i have no clue about vim-syntax-definitions. I just assumed adding the `WeakSet`-keyword at that position may add support of `WeakSet` objects.

In case this PR isn't appropriate any hint how to improve it would be welcome.