### PR TITLE
Highlight function calls same as function names 

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -285,6 +285,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsGenerator            jsFunction
   HiLink jsArrowFuncArgs        jsFuncArgs
   HiLink jsFuncName             Function
+  HiLink jsFuncCall             Function
   HiLink jsClassFuncName        jsFuncName
   HiLink jsObjectFuncName       Function
   HiLink jsArguments            Special


### PR DESCRIPTION
I had the following issue: function calls on objects are not highlighted and are colored the same way as parens or "noise". I'd expect them to be the same color as function names (which is the handled like that in most editors/ides afaik).

I wasn't sure if this was a missing feature or a bug so I used this simple vim plugin config to reproduce  my issue securely:
```
call plug#begin('~/.config/nvim/plugged')

" javascript syntax highlighting and indentation
Plug 'pangloss/vim-javascript'

call plug#end()

" Enable syntax highlighting for JSDoc
let g:javascript_plugin_jsdoc = 1
```

Before:
![no-fn-call-highlighting](https://user-images.githubusercontent.com/5814041/36379327-36e9db6e-15d2-11e8-8bae-d2db67c59bc8.png)

After: 
![fn-call-highlighting](https://user-images.githubusercontent.com/5814041/36379330-3aebbf34-15d2-11e8-8aba-f054a08de3a7.png)

I don't have a lot of knowledge of vimscript so if this should be addressed elswhere in the code could someone point me in that direction.
