### PR TITLE
Highlight Flow opaque keyboard

### DIFF
--- a/extras/flow.vim
+++ b/extras/flow.vim
@@ -31,7 +31,7 @@ syntax region  jsFlowFunctionGroup      contained matchgroup=jsFlowNoise start=/
 syntax region  jsFlowClassGroup         contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsClassBlock
 syntax region  jsFlowClassFunctionGroup contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncArgs
 
-syntax region  jsFlowTypeStatement                                   start=/type\%(\s\+\k\)\@=/    end=/=\@=/ contains=jsFlowTypeOperator oneline skipwhite skipempty nextgroup=jsFlowTypeValue keepend
+syntax region  jsFlowTypeStatement                                   start=/\(opaque\s\+\)\?type\%(\s\+\k\)\@=/    end=/=\@=/ contains=jsFlowTypeOperator oneline skipwhite skipempty nextgroup=jsFlowTypeValue keepend
 syntax region  jsFlowTypeValue      contained     matchgroup=jsFlowNoise start=/=/       end=/[\n;]/ contains=@jsFlowCluster,jsFlowGroup,jsFlowMaybe
 syntax match   jsFlowTypeOperator   contained /=/ containedin=jsFlowTypeValue
 syntax match   jsFlowTypeOperator   contained /=/


### PR DESCRIPTION
Flow supports "opaque types", which are types whose definition is known in the
file where it's defined, but hidden in all other files (this allows creating
abstract types, a sort of information hiding.)

<https://flow.org/en/docs/types/opaque-types/>

As an example of the syntax:

```js
// @flow

// Type representing an opaque identifier.
// Outside of this file, Id can't be used as a number.
opaque type Id = number;

// Inside this file, Id *can* be used as a number.
let next: Id = 0;

export const freshId = (): Id => {
  return next++;
}
```


I've been using this change locally for a couple months without issue, so it
should be pretty safe to merge.