### PR TITLE
ftdetect fixes

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,8 +1,11 @@
-au BufNewFile,BufRead *.{js,mjs,jsm,es,es6},Jakefile setf javascript
-
 fun! s:SelectJavascript()
   if getline(1) =~# '^#!.*/bin/\%(env\s\+\)\?node\>'
     set ft=javascript
   endif
 endfun
-au BufNewFile,BufRead * call s:SelectJavascript()
+
+augroup javascript_syntax_detection
+  autocmd!
+  autocmd BufNewFile,BufRead *.{js,mjs,jsm,es,es6},Jakefile setfiletype javascript
+  autocmd BufNewFile,BufRead * call s:SelectJavascript()
+augroup END

--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,14 +1,5 @@
 au BufNewFile,BufRead *.{js,mjs,jsm,es,es6},Jakefile setf javascript
 
-fun! s:SourceFlowSyntax()
-  if !exists('javascript_plugin_flow') && !exists('b:flow_active') &&
-        \ search('\v\C%^\_s*%(//\s*|/\*[ \t\n*]*)\@flow>','nw')
-    runtime extras/flow.vim
-    let b:flow_active = 1
-  endif
-endfun
-au FileType javascript au BufRead,BufWritePost <buffer> call s:SourceFlowSyntax()
-
 fun! s:SelectJavascript()
   if getline(1) =~# '^#!.*/bin/\%(env\s\+\)\?node\>'
     set ft=javascript


### PR DESCRIPTION
A couple tweaks to our ftdetect script.

1) I don't think flow detection belongs here, it's not a filetype tweak. I also fear putting a search like that as an autocommand could cause potential performance problems. Also it brings flow support in line with our other plugin features.

2) The way we were handling autocmds was kinda bad practice, so I made them part of an augroup that will clear itself if the file gets re-sourced.