### PR TITLE
Fix s:ExprCol() sometimes go into infinity loop when calculating indent

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -204,7 +204,8 @@ function s:ExprCol()
     return 1
   endif
   let bal = 0
-  while s:SearchLoop('[{}?:]','bW',s:skip_expr)
+  let lines = line('.')
+  while s:SearchLoop('[{}?:]','bW',s:skip_expr) && bal >= -lines
     if s:LookingAt() == ':'
       let bal -= !search('\m:\%#','bW')
     elseif s:LookingAt() == '?'


### PR DESCRIPTION
I have no idea how to reproduce it in a simple way...

In the case, I'm working with several tabs and buffers, 
when I edit a `.vue` file, I typing <kbd>o</kbd> (or <kbd>CR</kbd>, <kbd>O</kbd>, <kbd>S</kbd>, <kbd>c</kbd><kbd>c</kbd> that will insert a newline), it happened.

But when I open only one `.vue` file, that will fall into infinity loop before, it works correctly...

And not only `.vue` but `.js` could cause the same error when lots of buffer was opened.

Sorry for no helpful information about it (ノω・。)

![2018-07-28 7 26 48](https://user-images.githubusercontent.com/11359892/43356108-443467b0-929d-11e8-9c29-0bcb3d03d968.png)

![2018-07-28 7 27 22](https://user-images.githubusercontent.com/11359892/43356113-4a8051a6-929d-11e8-9f92-49d452926217.png)
