### PR TITLE
Improve Generic Support

### DIFF
--- a/extras/flow.vim
+++ b/extras/flow.vim
@@ -3,13 +3,14 @@ syntax region  jsFlowArgumentDef    contained                        start=/:/  
 syntax region  jsFlowArray          contained matchgroup=jsFlowNoise start=/\[/   end=/\]/        contains=@jsFlowCluster,jsComment fold
 syntax region  jsFlowObject         contained matchgroup=jsFlowNoise start=/{/    end=/}/         contains=@jsFlowCluster,jsComment fold
 syntax region  jsFlowExactObject    contained matchgroup=jsFlowNoise start=/{|/   end=/|}/       contains=@jsFlowCluster,jsComment fold
-syntax region  jsFlowParens         contained matchgroup=jsFlowNoise start=/(/  end=/)/ contains=@jsFlowCluster keepend fold
+syntax region  jsFlowParens         contained matchgroup=jsFlowNoise start=/(/  end=/)/ contains=@jsFlowCluster nextgroup=jsFlowArrow skipwhite keepend extend fold
 syntax match   jsFlowNoise          contained /[:;,<>]/
 syntax keyword jsFlowType           contained boolean number string null void any mixed JSON array Function object array bool class
 syntax keyword jsFlowTypeof         contained typeof skipempty skipwhite nextgroup=jsFlowTypeCustom,jsFlowType
-syntax match   jsFlowTypeCustom     contained /[0-9a-zA-Z_.]*/ skipwhite skipempty nextgroup=jsFlowGroup
-syntax region  jsFlowGroup          contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster
-syntax region  jsFlowArrowArguments contained matchgroup=jsFlowNoise start=/(/  end=/)\%(\s*=>\)\@=/ oneline skipwhite skipempty nextgroup=jsFlowArrow contains=@jsFlowCluster
+syntax match   jsFlowTypeCustom     contained /[0-9a-zA-Z_.]*/ skipwhite skipempty nextgroup=jsFlowGeneric
+syntax region  jsFlowGeneric                  matchgroup=jsFlowNoise start=/\k\@<=</ end=/>/ contains=@jsFlowCluster containedin=@jsExpression,jsFlowDeclareBlock
+syntax region  jsFlowGeneric        contained matchgroup=jsFlowNoise start=/</ end=/>(\@=/ oneline contains=@jsFlowCluster containedin=@jsExpression,jsFlowDeclareBlock
+syntax region  jsFlowObjectGeneric  contained matchgroup=jsFlowNoise start=/\k\@<=</ end=/>/ contains=@jsFlowCluster nextgroup=jsFuncArgs
 syntax match   jsFlowArrow          contained /=>/ skipwhite skipempty nextgroup=jsFlowType,jsFlowTypeCustom,jsFlowParens
 syntax match   jsFlowObjectKey      contained /[0-9a-zA-Z_$?]*\(\s*:\)\@=/ contains=jsFunctionKey,jsFlowMaybe skipwhite skipempty nextgroup=jsObjectValue containedin=jsObject
 syntax match   jsFlowOrOperator     contained /|/ skipwhite skipempty nextgroup=@jsFlowCluster
@@ -17,7 +18,7 @@ syntax keyword jsFlowImportType     contained type typeof skipwhite skipempty ne
 syntax match   jsFlowWildcard       contained /*/
 
 syntax match   jsFlowReturn         contained /:\s*/ contains=jsFlowNoise skipwhite skipempty nextgroup=@jsFlowReturnCluster,jsFlowArrow,jsFlowReturnParens
-syntax region  jsFlowReturnObject   contained matchgroup=jsFlowNoise start=/{/    end=/}/  contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncBlock,jsFlowReturnOrOp fold
+syntax region  jsFlowReturnObject   contained matchgroup=jsFlowNoise start=/{/    end=/}/  contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncBlock,jsFlowReturnOrOp extend fold
 syntax region  jsFlowReturnArray    contained matchgroup=jsFlowNoise start=/\[/   end=/\]/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncBlock,jsFlowReturnOrOp fold
 syntax region  jsFlowReturnParens   contained matchgroup=jsFlowNoise start=/(/    end=/)/  contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncBlock,jsFlowReturnOrOp,jsFlowReturnArrow fold
 syntax match   jsFlowReturnArrow    contained /=>/ skipwhite skipempty nextgroup=@jsFlowReturnCluster
@@ -31,9 +32,10 @@ syntax keyword jsFlowTypeofReturn   contained typeof skipempty skipwhite nextgro
 syntax region  jsFlowFunctionGroup      contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncArgs
 syntax region  jsFlowClassGroup         contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsClassBlock
 syntax region  jsFlowClassFunctionGroup contained matchgroup=jsFlowNoise start=/</ end=/>/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsFuncArgs
+syntax match   jsFlowObjectFuncName contained /\<\K\k*<\@=/ skipwhite skipempty nextgroup=jsFlowObjectGeneric containedin=jsObject
 
 syntax region  jsFlowTypeStatement                                   start=/\(opaque\s\+\)\?type\%(\s\+\k\)\@=/    end=/=\@=/ contains=jsFlowTypeOperator oneline skipwhite skipempty nextgroup=jsFlowTypeValue keepend
-syntax region  jsFlowTypeValue      contained     matchgroup=jsFlowNoise start=/=/ end=/\%(;\|\n\%(\s*|\)\@!\)/ contains=@jsFlowCluster,jsFlowGroup,jsFlowMaybe
+syntax region  jsFlowTypeValue      contained     matchgroup=jsFlowNoise start=/=/ end=/\%(;\|\n\%(\s*|\)\@!\)/ contains=@jsFlowCluster,jsFlowGeneric,jsFlowMaybe
 syntax match   jsFlowTypeOperator   contained /=/ containedin=jsFlowTypeValue
 syntax match   jsFlowTypeOperator   contained /=/
 syntax keyword jsFlowTypeKeyword    contained type
@@ -42,20 +44,17 @@ syntax keyword jsFlowDeclare                  declare skipwhite skipempty nextgr
 syntax match   jsFlowClassProperty  contained /\<[0-9a-zA-Z_$]*\>:\@=/ skipwhite skipempty nextgroup=jsFlowClassDef containedin=jsClassBlock
 syntax region  jsFlowClassDef       contained start=/:/    end=/\%(\s*[,=;)\n]\)\@=/ contains=@jsFlowCluster skipwhite skipempty nextgroup=jsClassValue
 
-syntax region  jsFlowModule         contained start=/module/ end=/{\@=/ skipempty skipwhite nextgroup=jsFlowDeclareBlock contains=jsString
+syntax region  jsFlowModule         contained start=/module/ end=/\%({\|:\)\@=/ skipempty skipwhite nextgroup=jsFlowDeclareBlock contains=jsString
 syntax region  jsFlowInterface      contained start=/interface/ end=/{\@=/ skipempty skipwhite nextgroup=jsFlowInterfaceBlock contains=@jsFlowCluster
 syntax region  jsFlowDeclareBlock   contained matchgroup=jsFlowNoise start=/{/ end=/}/ contains=jsFlowDeclare,jsFlowNoise fold
 
-" NOTE: It appears the nextgroup was causing a ton of breakages... testing it
-" witout a nextgroup, but keeping this arround for reference incase something breaks
-" syntax match   jsFlowMaybe          contained /?/ nextgroup=jsFlowType,jsFlowTypeCustom,jsFlowParens,jsFlowArrowArguments,jsFlowObject,jsFlowReturnObject extend keepend
 syntax match   jsFlowMaybe          contained /?/
-syntax region  jsFlowInterfaceBlock contained matchgroup=jsFlowNoise start=/{/ end=/}/ contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsObjectMethodType,jsGenerator,jsComment,jsObjectStringKey,jsSpreadExpression,jsFlowNoise keepend fold
+syntax region  jsFlowInterfaceBlock contained matchgroup=jsFlowNoise start=/{/ end=/}/ contains=jsObjectKey,jsObjectKeyString,jsObjectKeyComputed,jsObjectSeparator,jsObjectFuncName,jsFlowObjectFuncName,jsObjectMethodType,jsGenerator,jsComment,jsObjectStringKey,jsSpreadExpression,jsFlowNoise,jsFlowParens,jsFlowGeneric keepend fold
 
 syntax region  jsFlowParenAnnotation contained start=/:/ end=/[,=)]\@=/ containedin=jsParen contains=@jsFlowCluster
 
 syntax cluster jsFlowReturnCluster            contains=jsFlowNoise,jsFlowReturnObject,jsFlowReturnArray,jsFlowReturnKeyword,jsFlowReturnGroup,jsFlowReturnMaybe,jsFlowReturnOrOp,jsFlowWildcardReturn,jsFlowReturnArrow,jsFlowTypeofReturn
-syntax cluster jsFlowCluster                  contains=jsFlowArray,jsFlowObject,jsFlowExactObject,jsFlowNoise,jsFlowTypeof,jsFlowType,jsFlowGroup,jsFlowArrowArguments,jsFlowMaybe,jsFlowParens,jsFlowOrOperator,jsFlowWildcard
+syntax cluster jsFlowCluster                  contains=jsFlowArray,jsFlowObject,jsFlowExactObject,jsFlowNoise,jsFlowTypeof,jsFlowType,jsFlowGeneric,jsFlowMaybe,jsFlowParens,jsFlowOrOperator,jsFlowWildcard
 
 if version >= 508 || !exists("did_javascript_syn_inits")
   if version < 508
@@ -75,17 +74,17 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsFlowObject             PreProc
   HiLink jsFlowExactObject        PreProc
   HiLink jsFlowParens             PreProc
-  HiLink jsFlowGroup              PreProc
+  HiLink jsFlowGeneric            PreProc
+  HiLink jsFlowObjectGeneric      jsFlowGeneric
   HiLink jsFlowReturn             PreProc
   HiLink jsFlowParenAnnotation    PreProc
   HiLink jsFlowReturnObject       jsFlowReturn
   HiLink jsFlowReturnArray        jsFlowArray
   HiLink jsFlowReturnParens       jsFlowParens
-  HiLink jsFlowReturnGroup        jsFlowGroup
+  HiLink jsFlowReturnGroup        jsFlowGeneric
   HiLink jsFlowFunctionGroup      PreProc
   HiLink jsFlowClassGroup         PreProc
   HiLink jsFlowClassFunctionGroup PreProc
-  HiLink jsFlowArrowArguments     PreProc
   HiLink jsFlowArrow              PreProc
   HiLink jsFlowReturnArrow        PreProc
   HiLink jsFlowTypeStatement      PreProc
@@ -105,5 +104,6 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsFlowWildcardReturn     PreProc
   HiLink jsFlowImportType         PreProc
   HiLink jsFlowTypeValue          PreProc
+  HiLink jsFlowObjectFuncName     jsObjectFuncName
   delcommand HiLink
 endif


### PR DESCRIPTION
The biggest feature upgrade here is actual support for generics in function calls:

```
arr.reduce<number>(callback, 0);
```

Additionally I took a chance to improve other areas of generic support, as well as fix a bunch of other random bugs I found that are much too annoying to document here.

It's possible these changes may have other unintended consequences, so I will sit on this PR for a few days before merging.