### PR TITLE
[WIP] Fix higlighting of arrow function args with parens

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -168,14 +168,14 @@ syntax keyword jsArguments            contained arguments
 syntax keyword jsForAwait             contained await skipwhite skipempty nextgroup=jsParenRepeat
 
 " Matches a single keyword argument with no parens
-syntax match   jsArrowFuncArgs  /\<\K\k*\ze\s*=>/ skipwhite contains=jsFuncArgs skipwhite skipempty nextgroup=jsArrowFunction extend
+syntax match   jsArrowFuncArgs  /\<\K\k*\ze\s*=>/ skipwhite skipwhite skipempty nextgroup=jsArrowFunctionArrow extend
 " Matches a series of arguments surrounded in parens
-syntax match   jsArrowFuncArgs  /([^()]*)\ze\s*=>/ contains=jsFuncArgs skipempty skipwhite nextgroup=jsArrowFunction extend
+syntax region  jsArrowFuncArgs        contained matchgroup=jsFuncParens      start=/\(\>\s*\)\@<!(/ end=/)\ze\s*\(:\|=>\)/ contains=jsFuncArgCommas,jsComment,jsFuncArgExpression,jsDestructuringBlock,jsDestructuringArray,jsRestExpression,jsFlowArgumentDef skipwhite skipempty nextgroup=jsArrowFunctionArrow,jsFlowReturn extend fold
 
 exe 'syntax match jsFunction /\<function\>/      skipwhite skipempty nextgroup=jsGenerator,jsFuncName,jsFuncArgs,jsFlowFunctionGroup skipwhite '.(exists('g:javascript_conceal_function') ? 'conceal cchar='.g:javascript_conceal_function : '')
-exe 'syntax match jsArrowFunction /=>/           skipwhite skipempty nextgroup=jsFuncBlock,jsCommentFunction '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')
-exe 'syntax match jsArrowFunction /()\ze\s*=>/   skipwhite skipempty nextgroup=jsArrowFunction '.(exists('g:javascript_conceal_noarg_arrow_function') ? 'conceal cchar='.g:javascript_conceal_noarg_arrow_function : '')
-exe 'syntax match jsArrowFunction /_\ze\s*=>/    skipwhite skipempty nextgroup=jsArrowFunction '.(exists('g:javascript_conceal_underscore_arrow_function') ? 'conceal cchar='.g:javascript_conceal_underscore_arrow_function : '')
+exe 'syntax match jsArrowFunctionArrow /=>/      skipwhite skipempty nextgroup=jsFuncBlock,jsCommentFunction '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')
+exe 'syntax match jsArrowFunction /()\ze\s*=>/   skipwhite skipempty nextgroup=jsArrowFunctionArrow '.(exists('g:javascript_conceal_noarg_arrow_function') ? 'conceal cchar='.g:javascript_conceal_noarg_arrow_function : '')
+exe 'syntax match jsArrowFunction /_\ze\s*=>/    skipwhite skipempty nextgroup=jsArrowFunctionArrow '.(exists('g:javascript_conceal_underscore_arrow_function') ? 'conceal cchar='.g:javascript_conceal_underscore_arrow_function : '')
 
 " Classes
 syntax keyword jsClassKeyword           contained class
@@ -282,7 +282,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsCatch                Exception
   HiLink jsAsyncKeyword         Keyword
   HiLink jsForAwait             Keyword
-  HiLink jsArrowFunction        Type
+  HiLink jsArrowFunctionArrow   Type
   HiLink jsFunction             Type
   HiLink jsGenerator            jsFunction
   HiLink jsArrowFuncArgs        jsFuncArgs


### PR DESCRIPTION
### Purpose

The arguments surrounded by the parens of the arrow function should be matched as a region.

### Example:

```js
const func = ({
	foo,
	bar,
	baz = `baz`
}) => {
	// function body
};
```

The destructuring argument was highlighted as a `jsObject` group before.

![image](https://user-images.githubusercontent.com/3297602/61573388-72630900-aae0-11e9-8b9f-710668e7ab90.png)

And this PR resolves this problem.

![image](https://user-images.githubusercontent.com/3297602/61573397-a4746b00-aae0-11e9-9f20-d70b8aacc9d6.png)

### Few Explanations:

- The start regexp is to distinct from the function call
- The end regexp is to compatible with flow syntax
- The `=>` is now matched as `jsArrowFunctionArrow` separately.

### Related Issues

- #1177
- #1092