### PR TITLE
Fix ftdetect interfering with other plugins

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -4,8 +4,5 @@ fun! s:SelectJavascript()
   endif
 endfun
 
-augroup javascript_syntax_detection
-  autocmd!
-  autocmd BufNewFile,BufRead *.{js,mjs,jsm,es,es6},Jakefile setfiletype javascript
-  autocmd BufNewFile,BufRead * call s:SelectJavascript()
-augroup END
+autocmd BufNewFile,BufRead *.{js,mjs,jsm,es,es6},Jakefile setfiletype javascript
+autocmd BufNewFile,BufRead * call s:SelectJavascript()


### PR DESCRIPTION
Similar introduction of augroup in ftdetect happened in vim-go and was subsequently removed later (see reference). 

This is from the help doc `:help ftdetect`:
```
Note that there is no "augroup" command, this has already been done
when sourcing your file.  You could also use the pattern "*" and then
check the contents of the file to recognize it.
```

Reference:
https://github.com/Kuniwak/vint/issues/264
https://github.com/fatih/vim-go/pull/1645