### PR TITLE
Add flow syntax filetype

### DIFF
--- a/ftdetect/flow.vim
+++ b/ftdetect/flow.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.flow setfiletype flow

--- a/syntax/flow.vim
+++ b/syntax/flow.vim
@@ -1,0 +1,2 @@
+runtime syntax/javascript.vim
+runtime extras/flow.vim


### PR DESCRIPTION
use cases:
- flow's npm shipped library definitions (inside node_modules) file extensions are `.flow`s.
- [coc.nvim](//github.com/neoclide/coc.nvim) and maybe other lsp clients use this for syntax highlighting, (flow lsp returns flow markdowns(```flow) 
before:
![image](https://user-images.githubusercontent.com/13261088/65337005-99bb7c80-dbdc-11e9-8146-f1266cc62d58.png)
after:
![image](https://user-images.githubusercontent.com/13261088/65337062-b5bf1e00-dbdc-11e9-800a-824beeaf3ab0.png)


Closes #1186