### PR TITLE
Fix matching of jsClassProperty without an initial value

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -184,7 +184,7 @@ syntax match   jsClassNoise             contained /\./
 syntax match   jsClassFuncName          contained /\<\K\k*\ze\s*[(<]/ skipwhite skipempty nextgroup=jsFuncArgs,jsFlowClassFunctionGroup
 syntax match   jsClassMethodType        contained /\<\%([gs]et\|static\)\ze\s\+\K\k*/ skipwhite skipempty nextgroup=jsAsyncKeyword,jsClassFuncName,jsClassProperty
 syntax region  jsClassDefinition                  start=/\<class\>/ end=/\(\<extends\>\s\+\)\@<!{\@=/ contains=jsClassKeyword,jsExtendsKeyword,jsClassNoise,@jsExpression,jsFlowClassGroup skipwhite skipempty nextgroup=jsCommentClass,jsClassBlock,jsFlowClassGroup
-syntax match   jsClassProperty          contained /\<\K\k*\ze\s*=/ skipwhite skipempty nextgroup=jsClassValue,jsFlowClassDef
+syntax match   jsClassProperty          contained /\<\K\k*\ze\s*[=;]/ skipwhite skipempty nextgroup=jsClassValue,jsFlowClassDef
 syntax region  jsClassValue             contained start=/=/ end=/\_[;}]\@=/ contains=@jsExpression
 syntax region  jsClassPropertyComputed  contained matchgroup=jsBrackets start=/\[/ end=/]/ contains=@jsExpression skipwhite skipempty nextgroup=jsFuncArgs,jsClassValue extend
 syntax region  jsClassStringKey         contained start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1\|$+  contains=jsSpecial,@Spell extend skipwhite skipempty nextgroup=jsFuncArgs


### PR DESCRIPTION
Given the following code

```javascript
class Foo {
  bar;

  baz = 'biz';
}
```

The `baz` is properly matched as a `jsClassProperty` but `bar is
`jsClassBody`. The regex for `jsClassProperty` was requiring the `=`
that followed the property name. The changes allow value less
properties by allowing either `;` or `=` to follow the name.

`jsClassPropertyComputed` was not affected since that is matched by using the delimiters `[]` and
that works regardless of an initial value. But I noticed that for properties that have no semicolons
then the matching does not work for property values as well. I don't know if the recent spec
actually requires semicolons, so I didn't add it yet. But I would add it if class properties without
semicolons are still allowed.