### PR TITLE
eslint compiler improvements

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -3,6 +3,8 @@
 " Maintainer:   vim-javascript community
 " URL:          https://github.com/pangloss/vim-javascript
 
+compiler eslint
+
 setlocal iskeyword+=$ suffixesadd+=.js
 
 if exists('b:undo_ftplugin')

--- a/compiler/eslint.vim
+++ b/compiler/eslint.vim
@@ -12,5 +12,5 @@ if exists(":CompilerSet") != 2
   command! -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet makeprg=eslint\ -f\ compact\ %
-CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m
+CompilerSet makeprg=npx\ -q\ eslint\ -f\ unix
+CompilerSet errorformat&


### PR DESCRIPTION
Use `npx` instead of assuming eslint is installed globally.
(`npx` ships with `npm` since 5.2.0)

Exclude `%` from the `makeprg` command so that whole directories (or
the whole project) can be linted with `:make .` (the current file can
still be linted with `:make %`).

Use unix format since it's already included in the default
`errorformat`.

Automatically set compiler to eslint when editing a javascript file.