### PR TITLE
Add `.cjs` file extension support

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -4,5 +4,5 @@ fun! s:SelectJavascript()
   endif
 endfun
 
-autocmd BufNewFile,BufRead *.{js,mjs,jsm,es,es6},Jakefile setfiletype javascript
+autocmd BufNewFile,BufRead *.{js,mjs,cjs,jsm,es,es6},Jakefile setfiletype javascript
 autocmd BufNewFile,BufRead * call s:SelectJavascript()


### PR DESCRIPTION
As of Node 13.2.0, the `--experimental-modules` flag was removed making usage of ES modules available by default. As part of the Node ES modules support, they allow a package to define their default module type (which is how `.js` files are interpretted) and also allow using either `.cjs` or `.mjs` to explicitly declare a given file is of one format or the other.

We already had the `.mjs` extension supported so this adds `.cjs` to round out support for Node's ES module system.

References:

* [v13.2.0 release post unflagging `--experimental-modules`](https://nodejs.org/en/blog/release/v13.2.0/)
* [v14 documentation of ES Modules](https://nodejs.org/api/esm.html)