### PR TITLE
Fix multi-line arrow function argument highlighting

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -170,7 +170,7 @@ syntax keyword jsForAwait             contained await skipwhite skipempty nextgr
 " Matches a single keyword argument with no parens
 syntax match   jsArrowFuncArgs  /\<\K\k*\ze\s*=>/ skipwhite contains=jsFuncArgs skipwhite skipempty nextgroup=jsArrowFunction extend
 " Matches a series of arguments surrounded in parens
-syntax match   jsArrowFuncArgs  /([^()]*)\ze\s*=>/ contains=jsFuncArgs skipempty skipwhite nextgroup=jsArrowFunction extend
+syntax match   jsArrowFuncArgs  /(\_[^()]*\(\_[^()]*(\_[^()]*)\_[^()]*\)*)\ze\s*=>/ contains=jsFuncArgs skipempty skipwhite nextgroup=jsArrowFunction extend
 
 exe 'syntax match jsFunction /\<function\>/      skipwhite skipempty nextgroup=jsGenerator,jsFuncName,jsFuncArgs,jsFlowFunctionGroup skipwhite '.(exists('g:javascript_conceal_function') ? 'conceal cchar='.g:javascript_conceal_function : '')
 exe 'syntax match jsArrowFunction /=>/           skipwhite skipempty nextgroup=jsFuncBlock,jsCommentFunction '.(exists('g:javascript_conceal_arrow_function') ? 'conceal cchar='.g:javascript_conceal_arrow_function : '')


### PR DESCRIPTION
Current version:
![gnome-shell-screenshot-7UZUL0](https://user-images.githubusercontent.com/1108801/83645340-f339cf00-a5e4-11ea-99ef-cf194634d10b.png)

Patched version:
![gnome-shell-screenshot-WRCGL0](https://user-images.githubusercontent.com/1108801/83645252-d69d9700-a5e4-11ea-91ad-ecbf83fe5c21.png)

The pattern is made a little complex for the following case:
![gnome-shell-screenshot-NKWPL0](https://user-images.githubusercontent.com/1108801/83645749-6cd1bd00-a5e5-11ea-88bf-ae962a0641ef.png)
