### PR TITLE
Add known DOM element properties

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -30,6 +30,13 @@ syntax match   jsObjectProp     contained /\<\K\k*/
 syntax match   jsFuncCall       /\<\K\k*\ze\s*(/
 syntax match   jsParensError    /[)}\]]/
 
+" Known Properties
+syntax keyword jsElementProp attributes classList className clientHeight containedin=htmlEventDQ,htmlEventSQ
+syntax keyword jsElementProp clientLeft clientTop clientWidth computedName containedin=htmlEventDQ,htmlEventSQ
+syntax keyword jsElementProp computedRole id innerHTML localName namespaceURI containedin=htmlEventDQ,htmlEventSQ
+syntax keyword jsElementProp outerHTML part prefix scrollHeight scrollLeft containedin=htmlEventDQ,htmlEventSQ
+syntax keyword jsElementProp scrollTop scrollWidth shadowRootRead tagName containedin=htmlEventDQ,htmlEventSQ
+
 " Program Keywords
 syntax keyword jsStorageClass   const var let skipwhite skipempty nextgroup=jsDestructuringBlock,jsDestructuringArray,jsVariableDef
 syntax match   jsVariableDef    contained /\<\K\k*/ skipwhite skipempty nextgroup=jsFlowDefinition


### PR DESCRIPTION
From MDN: https://developer.mozilla.org/en-US/docs/Web/API/Element#Properties

Not sure if this is the best way to do this. But, for instance, if you are doing something like this in HTML:

```html
<div onclick="classList.toggle('foobar');"></div>
```

the `classList` property there doesn't get properly highlighted, since it doesn't follow a period. Might be useful to be explicit about these, although it also might be smart to limit the context in which they're valid matches.