### PR TITLE
Remove obsolete highlight definitions

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -368,14 +368,8 @@ if version >= 508 || !exists("did_javascript_syn_inits")
 
   HiLink jsDomErrNo             Constant
   HiLink jsDomNodeConsts        Constant
-  HiLink jsDomElemAttrs         Label
-  HiLink jsDomElemFuncs         PreProc
 
   HiLink jsHtmlEvents           Special
-  HiLink jsHtmlElemAttrs        Label
-  HiLink jsHtmlElemFuncs        PreProc
-
-  HiLink jsCssStyles            Label
 
   delcommand HiLink
 endif


### PR DESCRIPTION
These syntax groups/keywords are no longer defined, so strip them out of the highlighting definitions