### PR TITLE
Fix typescript detection bug

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,4 +1,8 @@
 fun! s:SelectJavascript()
+  if expand('%:e') ==# 'ts'
+    return
+  endif
+
   if getline(1) =~# '^#!.*/bin/\%(env\s\+\)\?node\>'
     set ft=javascript
   endif


### PR DESCRIPTION
I realized that when in a typescript file that includes a shebang line, the filetype is incorrectly detected as javascript. This check stops this incorrect detection.

My first thought was to add a configuration variable (hence the branch name), but I realized how limiting that is.