### PR TITLE
Highlight jsTemplateBrace

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -327,7 +327,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink jsRepeatBraces         Noise
   HiLink jsSwitchBraces         Noise
   HiLink jsSpecial              Special
-  HiLink jsTemplateBraces       Noise
+  HiLink jsTemplateBraces       Type
   HiLink jsGlobalObjects        Constant
   HiLink jsGlobalNodeObjects    Constant
   HiLink jsExceptions           Constant


### PR DESCRIPTION
Hi, I think the variable in the template string seems clearer if we highlight the `jsTemplaetBrace` group.

```javascript
const a = `${abc} + 123`
```
<img width="268" alt="Screen Shot 2020-08-13 at 6 39 43 PM" src="https://user-images.githubusercontent.com/13349592/90125286-5ccc1b80-dd94-11ea-9501-e431e4d3752f.png">

<img width="255" alt="Screen Shot 2020-08-13 at 6 42 03 PM" src="https://user-images.githubusercontent.com/13349592/90125459-afa5d300-dd94-11ea-94a3-28573ea831ae.png">

