### PR TITLE
Fixes highlighting for finally in certain cases.

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -104,7 +104,7 @@ syntax keyword jsDo                     do              skipwhite skipempty next
 syntax region  jsSwitchCase   contained matchgroup=jsLabel start=/\<\%(case\|default\)\>/ end=/:\@=/ contains=@jsExpression,jsLabel skipwhite skipempty nextgroup=jsSwitchColon keepend
 syntax keyword jsTry                    try             skipwhite skipempty nextgroup=jsTryCatchBlock
 syntax keyword jsFinally      contained finally         skipwhite skipempty nextgroup=jsFinallyBlock
-syntax keyword jsCatch        contained catch           skipwhite skipempty nextgroup=jsParenCatch
+syntax keyword jsCatch        contained catch           skipwhite skipempty nextgroup=jsParenCatch,jsTryCatchBlock
 syntax keyword jsException              throw
 syntax keyword jsAsyncKeyword           async await
 syntax match   jsSwitchColon   contained /::\@!/        skipwhite skipempty nextgroup=jsSwitchBlock


### PR DESCRIPTION
`jsCatch` can be followed by `jsParenCatch` or `jsTryCatchBlock`. A `catch` can either be followed directly by a block or [optionally have parens for an error parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#syntax). The original issue noticed that in the code
```js
try {} catch {} finally {}
```
`finally` was not realized as a keyword. This PR fixes that by allowing the `nextgroup` to be either parens or a block.