### PR TITLE
Allow newlines between function name and parens for function call

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -27,7 +27,7 @@ syntax case match
 syntax match   jsNoise          /[:,;]/
 syntax match   jsDot            /\./ skipwhite skipempty nextgroup=jsObjectProp,jsFuncCall,jsPrototype,jsTaggedTemplate
 syntax match   jsObjectProp     contained /\<\K\k*/
-syntax match   jsFuncCall       /\<\K\k*\ze\s*(/
+syntax match   jsFuncCall       /\<\K\k*\ze[\s\n]*(/
 syntax match   jsParensError    /[)}\]]/
 
 " Program Keywords


### PR DESCRIPTION
The intent is to have syntax highlighting for function calls where the paren is on a new line. This is the style guide for my work when the arguments list is big and/or contains functions so having highlighting for it would be nice.

example:

```javascript
myFunc
(
    () =>
    {
        // Some callback
    }
);
```