### PR TITLE
Add tilde ~ to jsDocParam for inner members

### DIFF
--- a/extras/jsdoc.vim
+++ b/extras/jsdoc.vim
@@ -18,7 +18,8 @@ syntax region jsDocTypeRecord   contained start=/{/ end=/}/ contains=jsDocTypeRe
 syntax region jsDocTypeRecord   contained start=/\[/ end=/\]/ contains=jsDocTypeRecord extend
 syntax region jsDocTypeNoParam  contained start="{" end="}" oneline
 syntax match  jsDocTypeNoParam  contained "\%(#\|\"\|\w\|\.\|:\|\/\)\+"
-syntax match  jsDocParam        contained "\%(#\|\$\|-\|'\|\"\|{.\{-}}\|\w\|\.\|:\|\/\|\[.\{-}]\|=\)\+"
+syntax match  jsDocParam        contained "\%(#\|\$\|-\|'\|\"\|{.\{-}}\|\w\|\~\|\.\|:\|\/\|\[.\{-}]\|=\)\+"
+
 syntax region jsDocSeeTag       contained matchgroup=jsDocSeeTag start="{" end="}" contains=jsDocTags
 
 if version >= 508 || !exists("did_javascript_syn_inits")


### PR DESCRIPTION
Added a tilde to the jsDocParam syntax match to support jsdoc3 namepaths style (i.e. when creating a typedef for an inner member).

See https://jsdoc.app/tags-typedef.html

### Previous Highlighting
<img width="412" alt="image" src="https://user-images.githubusercontent.com/4794493/184559580-a8baf60d-7768-4189-8f2b-b8ab65613406.png">

### New Highlighting
<img width="405" alt="image" src="https://user-images.githubusercontent.com/4794493/184559783-abdf7ffe-46c6-4b2f-a26b-32ce970c096b.png">
