### PR TITLE
Revise README to include a warning about foldmethod=syntax hanging du…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ augroup END
 
 Enables code folding for javascript based on our syntax file.
 
-Please note this can have a dramatic effect on performance.
+Please note this can have a dramatic effect on performance. In some terminals
+this may cause hangs during pasting. If you are affected by this, using
+a different foldmethod (such as indent) may provide a better experience.
 
 
 ## Concealing Characters


### PR DESCRIPTION
This clarifies in the appropriate section of the README.md that foldmethod=syntax can cause hanging when pasting in some terminals, to hopefully help future travellers.  Re: issue #1257 